### PR TITLE
improve performance

### DIFF
--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -1,9 +1,9 @@
 use tree_sitter::Node;
 
 /// Extract text content from a tree-sitter node
-pub fn get_node_text(node: &Node, sql: &str) -> String {
+pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
     let range = node.range();
-    sql[range.start_byte..range.end_byte].to_string()
+    &sql[range.start_byte..range.end_byte]
 }
 
 /// Find the first child node with the specified kind

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -57,7 +57,7 @@ fn extract_group_by_columns(select_node: &Node, sql: &str) -> Option<HashSet<Str
     for node in traverse(group_by_node.walk(), Order::Pre) {
         if node.kind() == "identifier" {
             let text = get_node_text(&node, sql);
-            columns.insert(text);
+            columns.insert(text.to_string());
         }
     }
 
@@ -79,7 +79,7 @@ fn check_select_expression(
             let field_text = get_node_text(&node, sql);
 
             // Check if the identifier is in GROUP BY
-            if !group_by_columns.contains(&field_text) {
+            if !group_by_columns.contains(field_text) {
                 return Some(Diagnostic::new(
                     node.start_position().row + 1,
                     node.start_position().column + 1,

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -7,16 +7,10 @@ use crate::rules::helpers::{find_child_of_kind, has_child_of_kind};
 pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
     let mut diagnostics = Vec::new();
 
-    let root = tree.root_node();
-
-    for cte_node in find_ctes(&root) {
-        if let Some(diagnostic) = check_unnecessary_order_by_in_scope(&cte_node, sql) {
-            diagnostics.push(diagnostic);
-        }
-    }
-
-    for subquery_node in find_subqueries(&root) {
-        if let Some(diagnostic) = check_unnecessary_order_by_in_scope(&subquery_node, sql) {
+    for node in traverse(tree.root_node().walk(), Order::Pre) {
+        if matches!(node.kind(), "cte" | "select_subexpression")
+            && let Some(diagnostic) = check_unnecessary_order_by_in_scope(&node, sql)
+        {
             diagnostics.push(diagnostic);
         }
     }
@@ -26,26 +20,6 @@ pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
     } else {
         Some(diagnostics)
     }
-}
-
-fn find_ctes<'a>(node: &'a Node<'a>) -> Vec<Node<'a>> {
-    let mut cte_nodes = Vec::new();
-    for n in traverse(node.walk(), Order::Pre) {
-        if n.kind() == "cte" {
-            cte_nodes.push(n);
-        }
-    }
-    cte_nodes
-}
-
-fn find_subqueries<'a>(node: &'a Node<'a>) -> Vec<Node<'a>> {
-    let mut subquery_nodes = Vec::new();
-    for n in traverse(node.walk(), Order::Pre) {
-        if n.kind() == "select_subexpression" {
-            subquery_nodes.push(n);
-        }
-    }
-    subquery_nodes
 }
 
 fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<Diagnostic> {

--- a/src/rules/unused_column_in_cte/models.rs
+++ b/src/rules/unused_column_in_cte/models.rs
@@ -36,7 +36,7 @@ impl ColumnInfo {
 
 impl Display for ColumnInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let table_name = self.table_name.clone().unwrap_or_default();
+        let table_name = self.table_name.as_deref().unwrap_or_default();
         write!(
             f,
             "{}:{}:{}:{}",


### PR DESCRIPTION
## Summary

- Merge two separate tree traversals into a single pass in `unnecessary_order_by` rule
- Change `get_node_text` return type from `String` to `&str` to avoid unnecessary heap allocations
- Replace `Option::clone()` with `as_deref()` in `ColumnInfo::Display` to avoid cloning