### PR TITLE
simplify rule return types from Option<Vec<Diagnostic>> to Vec<Diagno…

### DIFF
--- a/benches/memory_profile.rs
+++ b/benches/memory_profile.rs
@@ -20,15 +20,12 @@ fn run_check(name: &str, path: &str) {
     let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
 
     let tree = parse_sql(&sql);
-    let result = unused_column_in_cte::check(&tree, &sql);
+    let diagnostics = unused_column_in_cte::check(&tree, &sql);
 
-    match result {
-        Some(diagnostics) => {
-            println!("Found {} unused columns", diagnostics.len());
-        }
-        None => {
-            println!("No unused columns found");
-        }
+    if diagnostics.is_empty() {
+        println!("No unused columns found");
+    } else {
+        println!("Found {} unused columns", diagnostics.len());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,14 +45,15 @@ fn main() -> ExitCode {
 
     // stdin
     if args.files.is_empty() {
-        let mut handle = stdin.lock();
-        if let Some(diagnostics) = analyse_sql(&mut handle) {
-            for diagnostic in diagnostics {
-                eprintln!("{}", diagnostic);
-            }
-            return ExitCode::FAILURE;
+        let diagnostics = analyse_sql(&mut stdin.lock());
+        for diagnostic in &diagnostics {
+            eprintln!("{}", diagnostic);
         }
-        return ExitCode::SUCCESS;
+        return if diagnostics.is_empty() {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        };
     }
 
     // files
@@ -65,24 +66,22 @@ fn main() -> ExitCode {
 
     let mut all_diagnostics = Vec::new();
 
-    #[allow(clippy::collapsible_if)]
     for target in targets {
         let file_path = target.into_path();
         if let Ok(mut file) = fs::File::open(&file_path) {
-            if let Some(diagnostics) = analyse_sql(&mut file) {
-                for diagnostic in diagnostics {
-                    eprintln!("{}: {}", file_path.display(), diagnostic);
-                    all_diagnostics.push(diagnostic);
-                }
+            let diagnostics = analyse_sql(&mut file);
+            for diagnostic in &diagnostics {
+                eprintln!("{}: {}", file_path.display(), diagnostic);
             }
+            all_diagnostics.extend(diagnostics);
         }
     }
 
-    if !all_diagnostics.is_empty() {
-        return ExitCode::FAILURE;
+    if all_diagnostics.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
     }
-
-    ExitCode::SUCCESS
 }
 
 fn is_sql(entry: &DirEntry) -> bool {
@@ -93,7 +92,7 @@ fn is_sql(entry: &DirEntry) -> bool {
         .unwrap_or(false)
 }
 
-fn analyse_sql<F: Read>(f: &mut F) -> Option<Vec<Diagnostic>> {
+fn analyse_sql<F: Read>(f: &mut F) -> Vec<Diagnostic> {
     let mut sql = String::new();
     let _ = f.read_to_string(&mut sql);
 
@@ -102,32 +101,12 @@ fn analyse_sql<F: Read>(f: &mut F) -> Option<Vec<Diagnostic>> {
     let tree = parser.parse(&sql, None).unwrap();
 
     let mut diagnostics = Vec::new();
-
-    if let Some(diags) = compare_table_suffix_with_subquery::check(&tree, &sql) {
-        diagnostics.extend(diags);
-    }
-
-    if let Some(diags) = invalid_group_by::check(&tree, &sql) {
-        diagnostics.extend(diags);
-    }
-
-    if let Some(diags) = unnecessary_order_by::check(&tree, &sql) {
-        diagnostics.extend(diags);
-    }
-
-    if let Some(diags) = unused_column_in_cte::check(&tree, &sql) {
-        diagnostics.extend(diags);
-    }
-
-    if let Some(diags) = use_current_date::check(&tree, &sql) {
-        diagnostics.extend(diags);
-    }
-
-    if diagnostics.is_empty() {
-        None
-    } else {
-        Some(diagnostics)
-    }
+    diagnostics.extend(compare_table_suffix_with_subquery::check(&tree, &sql));
+    diagnostics.extend(invalid_group_by::check(&tree, &sql));
+    diagnostics.extend(unnecessary_order_by::check(&tree, &sql));
+    diagnostics.extend(unused_column_in_cte::check(&tree, &sql));
+    diagnostics.extend(use_current_date::check(&tree, &sql));
+    diagnostics
 }
 
 #[cfg(test)]
@@ -170,13 +149,8 @@ mod tests {
         let tree = parser.parse(&sql, None).unwrap();
 
         let mut diagnostics = Vec::new();
-        if let Some(diags) = compare_table_suffix_with_subquery::check(&tree, &sql) {
-            diagnostics.extend(diags);
-        }
-
-        if let Some(diags) = use_current_date::check(&tree, &sql) {
-            diagnostics.extend(diags);
-        }
+        diagnostics.extend(compare_table_suffix_with_subquery::check(&tree, &sql));
+        diagnostics.extend(use_current_date::check(&tree, &sql));
         assert!(diagnostics.len() > 1);
     }
 }

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -3,7 +3,7 @@ use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
 
-pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
+pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     for node in traverse(tree.walk(), Order::Pre) {
@@ -17,11 +17,7 @@ pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
         }
     }
 
-    if diagnostics.is_empty() {
-        None
-    } else {
-        Some(diagnostics)
-    }
+    diagnostics
 }
 
 fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Diagnostic> {

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -5,14 +5,8 @@ use tree_sitter_traversal::{Order, traverse};
 use crate::diagnostic::Diagnostic;
 use crate::rules::helpers::{find_child_of_kind, get_node_text};
 
-pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
-    let diagnostics = find_invalid_group_by(tree, sql);
-
-    if diagnostics.is_empty() {
-        None
-    } else {
-        Some(diagnostics)
-    }
+pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
+    find_invalid_group_by(tree, sql)
 }
 
 fn find_invalid_group_by(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
@@ -195,13 +189,7 @@ mod tests {
         let sql = fs::read_to_string(format!("./sql/{}", filename)).unwrap();
         let tree = parse_sql(&sql);
 
-        let result = check(&tree, &sql);
-        assert!(
-            result.is_some(),
-            "Expected to detect invalid GROUP BY in {}",
-            filename
-        );
-        let diagnostics = result.unwrap();
+        let diagnostics = check(&tree, &sql);
         assert_eq!(
             diagnostics.len(),
             expected_count,
@@ -222,9 +210,9 @@ mod tests {
         let sql = fs::read_to_string(format!("./sql/{}", filename)).unwrap();
         let tree = parse_sql(&sql);
 
-        let result = check(&tree, &sql);
+        let diagnostics = check(&tree, &sql);
         assert!(
-            result.is_none(),
+            diagnostics.is_empty(),
             "Expected no diagnostics for valid GROUP BY in {}",
             filename
         );

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -4,7 +4,7 @@ use tree_sitter_traversal::{Order, traverse};
 use crate::diagnostic::Diagnostic;
 use crate::rules::helpers::{find_child_of_kind, has_child_of_kind};
 
-pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
+pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     for node in traverse(tree.root_node().walk(), Order::Pre) {
@@ -15,11 +15,7 @@ pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
         }
     }
 
-    if diagnostics.is_empty() {
-        None
-    } else {
-        Some(diagnostics)
-    }
+    diagnostics
 }
 
 fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<Diagnostic> {
@@ -66,8 +62,7 @@ mod tests {
         let tree = parse_sql(&sql);
 
         let diagnostics = check(&tree, &sql);
-        assert!(diagnostics.is_some());
-        assert_eq!(diagnostics.unwrap().len(), expected_count);
+        assert_eq!(diagnostics.len(), expected_count);
     }
 
     #[test]
@@ -76,6 +71,6 @@ mod tests {
         let tree = parse_sql(&sql);
 
         let diagnostics = check(&tree, &sql);
-        assert!(diagnostics.is_none());
+        assert!(diagnostics.is_empty());
     }
 }

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -17,7 +17,7 @@ use visitors::{
     CteVisitor, PivotVisitor, QualifyVisitor, SelectStarVisitor, SelectVisitor, WhereVisitor,
 };
 
-pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
+pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut context = AnalysisContext::new(sql);
 
     let cte_visitor = CteVisitor;
@@ -39,24 +39,17 @@ pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
         pivot_visitor.visit(&node, &mut context);
     }
 
-    let unused_columns = context.collect_unused();
-
-    if unused_columns.is_empty() {
-        None
-    } else {
-        Some(
-            unused_columns
-                .into_iter()
-                .map(|col| {
-                    Diagnostic::new(
-                        col.row,
-                        col.col,
-                        format!("Unused column: {}", col.column_name),
-                    )
-                })
-                .collect(),
-        )
-    }
+    context
+        .collect_unused()
+        .into_iter()
+        .map(|col| {
+            Diagnostic::new(
+                col.row,
+                col.col,
+                format!("Unused column: {}", col.column_name),
+            )
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -86,22 +79,21 @@ mod tests {
             fs::read_to_string(&sql_path).unwrap_or_else(|_| panic!("Failed to read {}", sql_path));
 
         let tree = parse_sql(&sql);
-        let result = check(&tree, &sql);
+        let diagnostics = check(&tree, &sql);
 
         if expected_unused.is_empty() {
             assert!(
-                result.is_none(),
+                diagnostics.is_empty(),
                 "{}: Expected no unused columns, but found some",
                 filename
             );
         } else {
             assert!(
-                result.is_some(),
+                !diagnostics.is_empty(),
                 "{}: Expected unused columns, but found none",
                 filename
             );
 
-            let diagnostics = result.unwrap();
             let mut found_columns: Vec<String> = diagnostics
                 .iter()
                 .map(|d| {
@@ -144,16 +136,16 @@ mod tests {
             fs::read_to_string(&sql_path).unwrap_or_else(|_| panic!("Failed to read {}", sql_path));
 
         let tree = parse_sql(&sql);
-        let result = check(&tree, &sql);
+        let diagnostics = check(&tree, &sql);
 
         assert!(
-            result.is_none(),
+            diagnostics.is_empty(),
             "{}: Expected no unused columns, but found: {:?}",
             filename,
-            result.map(|d| d
+            diagnostics
                 .iter()
                 .map(|diag| diag.message().to_string())
-                .collect::<Vec<_>>())
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -3,7 +3,7 @@ use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
 
-pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
+pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     for node in traverse(tree.walk(), Order::Pre) {
@@ -12,11 +12,7 @@ pub fn check(tree: &Tree, sql: &str) -> Option<Vec<Diagnostic>> {
         }
     }
 
-    if diagnostics.is_empty() {
-        None
-    } else {
-        Some(diagnostics)
-    }
+    diagnostics
 }
 
 fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {


### PR DESCRIPTION
## Summary

- Change all rule `check()` functions and `analyse_sql()` to return `Vec<Diagnostic>` instead of `Option<Vec<Diagnostic>>`
- Remove boilerplate `if empty { None } else { Some(...) }` from every rule
- Simplify call sites from `if let Some(diags) = ...` to `diagnostics.extend(...)`
- Update tests and benchmarks accordingly