### PR TITLE
remove redundant validation and use get_node_text for consistency

### DIFF
--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -2,6 +2,7 @@ use tree_sitter::{Node, Tree};
 use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
+use crate::rules::helpers::get_node_text;
 
 pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
@@ -22,8 +23,7 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
 
 fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Diagnostic> {
     for node in traverse(n.walk(), Order::Pre) {
-        let range = node.range();
-        let text = &src[range.start_byte..range.end_byte];
+        let text = get_node_text(&node, src);
 
         if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
             let parent = node.parent().unwrap();
@@ -45,8 +45,7 @@ fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Dia
 
 fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Diagnostic> {
     for node in traverse(n.walk(), Order::Pre) {
-        let range = node.range();
-        let text = &src[range.start_byte..range.end_byte];
+        let text = get_node_text(&node, src);
 
         if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
             let parent = node.parent().unwrap();

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -2,8 +2,7 @@ use tree_sitter::Node;
 
 /// Extract text content from a tree-sitter node
 pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
-    let range = node.range();
-    &sql[range.start_byte..range.end_byte]
+    node.utf8_text(sql.as_bytes()).unwrap()
 }
 
 /// Find the first child node with the specified kind

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -21,11 +21,7 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
 fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<Diagnostic> {
     let query_expr = find_query_expr(scope_node)?;
 
-    let has_order_by = has_child_of_kind(&query_expr, "order_by_clause");
-    let has_limit = has_child_of_kind(&query_expr, "limit_clause");
-
-    if has_order_by
-        && !has_limit
+    if !has_child_of_kind(&query_expr, "limit_clause")
         && let Some(order_by_node) = find_child_of_kind(&query_expr, "order_by_clause")
     {
         return Some(new_unnecessary_order_by_warning(&order_by_node));

--- a/src/rules/unused_column_in_cte/utils.rs
+++ b/src/rules/unused_column_in_cte/utils.rs
@@ -2,16 +2,15 @@ use std::collections::HashMap;
 use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
+use crate::rules::helpers::get_node_text;
+
 use super::context::AnalysisContext;
 use super::models::ColumnInfo;
 
 /// Extract CTE name from a CTE node
 pub fn get_cte_name<'a>(cte_node: &Node, sql: &'a str) -> &'a str {
-    cte_node
-        .child_by_field_name("alias_name")
-        .unwrap()
-        .utf8_text(sql.as_bytes())
-        .unwrap()
+    let alias_node = cte_node.child_by_field_name("alias_name").unwrap();
+    get_node_text(&alias_node, sql)
 }
 
 /// Extract column name from a potentially qualified column reference
@@ -55,15 +54,14 @@ pub fn extract_table(from: Option<Node>, sql: &str) -> (Vec<String>, HashMap<Str
                 && let Some(first_child) = n.named_child(0)
                 && first_child.kind() == "identifier"
             {
-                let table_name = first_child.utf8_text(sql.as_bytes()).unwrap().to_string();
+                let table_name = get_node_text(&first_child, sql).to_string();
                 tables.push(table_name.clone());
 
                 // Check if there's an alias
                 for child in n.children(&mut n.walk()) {
                     if child.kind() == "as_alias" {
                         if let Some(alias_node) = child.named_children(&mut child.walk()).last() {
-                            let alias_name =
-                                alias_node.utf8_text(sql.as_bytes()).unwrap().to_string();
+                            let alias_name = get_node_text(&alias_node, sql).to_string();
                             alias_map.insert(alias_name, table_name.clone());
                         }
                         break;
@@ -131,7 +129,7 @@ pub fn extract_and_mark_fields(
             return;
         }
 
-        let field_text = node.utf8_text(sql.as_bytes()).unwrap_or("");
+        let field_text = get_node_text(node, sql);
         let col_name = extract_column_name(field_text);
 
         // Find which table this column belongs to

--- a/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
@@ -1,5 +1,6 @@
 use tree_sitter::Node;
 
+use crate::rules::helpers::get_node_text;
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
 };
@@ -117,7 +118,7 @@ fn extract_column_name_without_alias(
     select_expr: &Node,
     sql: &str,
 ) -> (String, String, Option<String>) {
-    let expr = select_expr.utf8_text(sql.as_bytes()).unwrap().to_string();
+    let expr = get_node_text(select_expr, sql).to_string();
     let column_name = utils::extract_column_name(&expr).to_string();
     let source = if column_name != expr {
         Some(column_name.clone())
@@ -137,13 +138,13 @@ fn extract_alias_info(
     let alias_name = alias_node
         .named_children(&mut alias_node.walk())
         .last()
-        .map(|n| n.utf8_text(sql.as_bytes()).unwrap().to_string())
+        .map(|n| get_node_text(&n, sql).to_string())
         .unwrap_or_default();
 
     // Extract original column (first named child of select_expression)
     let original = select_expr
         .named_child(0)
-        .map(|n| n.utf8_text(sql.as_bytes()).unwrap().to_string())
+        .map(|n| get_node_text(&n, sql).to_string())
         .unwrap_or_else(|| alias_name.clone());
 
     // source_column is the base column name without table prefix

--- a/src/rules/unused_column_in_cte/visitors/distinct_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/distinct_visitor.rs
@@ -1,5 +1,6 @@
 use tree_sitter::Node;
 
+use crate::rules::helpers::get_node_text;
 use crate::rules::unused_column_in_cte::{context::AnalysisContext, visitor::NodeVisitor};
 
 /// Visitor for processing SELECT DISTINCT
@@ -17,10 +18,9 @@ impl NodeVisitor for DistinctVisitor {
         let sql = context.sql();
 
         // Check if this SELECT has DISTINCT
-        let has_distinct = node.children(&mut node.walk()).any(|child| {
-            let text = child.utf8_text(sql.as_bytes()).unwrap_or("");
-            text.eq_ignore_ascii_case("distinct")
-        });
+        let has_distinct = node
+            .children(&mut node.walk())
+            .any(|child| get_node_text(&child, sql).eq_ignore_ascii_case("distinct"));
 
         if !has_distinct {
             return;
@@ -33,7 +33,7 @@ impl NodeVisitor for DistinctVisitor {
                 // Get CTE name
                 let cte_name = parent
                     .child_by_field_name("alias_name")
-                    .and_then(|n| n.utf8_text(sql.as_bytes()).ok())
+                    .map(|n| get_node_text(&n, sql))
                     .unwrap_or("");
 
                 // Mark all columns in this CTE as used

--- a/src/rules/unused_column_in_cte/visitors/select_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_visitor.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use tree_sitter::Node;
 
+use crate::rules::helpers::get_node_text;
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
 };
@@ -91,7 +92,7 @@ fn find_parent_cte_name(select_node: &Node, sql: &str) -> String {
         if parent.kind() == "cte" {
             return parent
                 .child_by_field_name("alias_name")
-                .and_then(|n| n.utf8_text(sql.as_bytes()).ok())
+                .map(|n| get_node_text(&n, sql))
                 .unwrap_or("")
                 .to_string();
         }
@@ -111,7 +112,7 @@ fn extract_field_references_from_expression(
 ) {
     // Process current node if it's a field or identifier
     if node.kind() == "field" || node.kind() == "identifier" {
-        let field_text = node.utf8_text(sql.as_bytes()).unwrap_or("");
+        let field_text = get_node_text(node, sql);
         let col_name = utils::extract_column_name(field_text);
 
         // Skip if this is a function name
@@ -162,7 +163,7 @@ fn extract_final_select_columns(
             if !has_direct_field {
                 // Fallback: treat the whole expression text as a column reference
                 // This handles cases where tree-sitter doesn't create a 'field' node
-                let column_text = child.utf8_text(sql.as_bytes()).unwrap();
+                let column_text = get_node_text(&child, sql);
                 let col_name = utils::extract_column_name(column_text);
 
                 let table = utils::find_original_table(
@@ -226,7 +227,7 @@ fn extract_all_fields_into_vec(
     // Note: tree-sitter may use 'field' for qualified references (table.column)
     // and 'identifier' for simple column references
     if node.kind() == "field" || node.kind() == "identifier" {
-        let field_text = node.utf8_text(sql.as_bytes()).unwrap_or("");
+        let field_text = get_node_text(node, sql);
         let col_name = utils::extract_column_name(field_text);
 
         // Skip if this looks like a function name (parent is function_call with this as name)

--- a/src/rules/unused_column_in_cte/visitors/where_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/where_visitor.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
+use crate::rules::helpers::get_node_text;
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
 };
@@ -80,7 +81,7 @@ fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
             // Extract identifiers from UNNEST - these are the column references
             for unnest_child in traverse(child.walk(), Order::Pre) {
                 if unnest_child.kind() == "identifier" || unnest_child.kind() == "field" {
-                    let column_text = unnest_child.utf8_text(sql.as_bytes()).unwrap();
+                    let column_text = get_node_text(&unnest_child, sql);
 
                     // Resolve table name for this column
                     let table = if column_text.contains('.') {
@@ -140,7 +141,7 @@ fn extract_columns_from_condition(
                 continue;
             }
 
-            let column_text = child.utf8_text(sql.as_bytes()).unwrap().to_string();
+            let column_text = get_node_text(&child, sql).to_string();
 
             // Resolve table name for this column
             let table = if column_text.contains('.') {

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -2,6 +2,7 @@ use tree_sitter::{Node, Tree};
 use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
+use crate::rules::helpers::get_node_text;
 
 pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
@@ -16,13 +17,12 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
 }
 
 fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {
-    let range = node.range();
-    let text = &src[range.start_byte..range.end_byte];
+    let text = get_node_text(&node, src);
 
     if node.kind() == "identifier" && text.eq_ignore_ascii_case("current_date") {
         return Some(new_current_date_warning(
-            range.start_point.row,
-            range.start_point.column,
+            node.range().start_point.row,
+            node.range().start_point.column,
         ));
     }
     None


### PR DESCRIPTION
## Summary

- Unify all node text extraction to use `get_node_text` helper, replacing direct byte slicing and `utf8_text` calls across 8 files
- Remove redundant `has_child_of_kind` + `find_child_of_kind` double lookup in `unnecessary_order_by` rule