### PR TITLE
Harden non-test code against panics/overflow and add meaningful tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,31 @@ harness = false
 [[bench]]
 name = "memory_profile"
 harness = false
+
+[profile.release]
+overflow-checks = true
+
+# Hardening gates: fail loudly at build time, never silently at runtime.
+# Panic-prone constructs and silent overflow are denied in non-test code;
+# test/bench modules opt out with a scoped `#[allow(..., reason = "test code")]`.
+[lints.rust]
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "deny"
+
+[lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+unreachable = "deny"
+todo = "deny"
+unimplemented = "deny"
+indexing_slicing = "deny"
+string_slice = "deny"
+unwrap_in_result = "deny"
+arithmetic_side_effects = "deny"
+as_conversions = "deny"
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_sign_loss = "deny"
+let_underscore_must_use = "deny"
+allow_attributes_without_reason = "deny"

--- a/benches/memory_profile.rs
+++ b/benches/memory_profile.rs
@@ -1,6 +1,13 @@
 // Memory profiling benchmark using dhat
 // Run with: cargo bench --bench memory_profile
 // Results will be in dhat-heap.json, visualize at https://nnethercote.github.io/dh_view/dh_view.html
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::arithmetic_side_effects,
+    reason = "benchmark code"
+)]
 
 use std::fs;
 use tree_sitter::Parser as TsParser;

--- a/benches/unused_column_in_cte.rs
+++ b/benches/unused_column_in_cte.rs
@@ -1,3 +1,11 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::arithmetic_side_effects,
+    reason = "benchmark code"
+)]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::fs;
 use std::hint::black_box;

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -32,3 +32,22 @@ impl Display for Diagnostic {
         write!(f, "{}:{}: {}", self.row, self.col, self.message)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accessors_return_the_constructed_values() {
+        let d = Diagnostic::new(3, 5, "boom".to_string());
+        assert_eq!(d.row(), 3);
+        assert_eq!(d.col(), 5);
+        assert_eq!(d.message(), "boom");
+    }
+
+    #[test]
+    fn display_formats_as_row_col_message() {
+        let d = Diagnostic::new(3, 5, "boom".to_string());
+        assert_eq!(format!("{}", d), "3:5: boom");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,13 @@ fn main() -> ExitCode {
     let targets = args.files.into_iter().flat_map(|f| {
         WalkDir::new(f)
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(|e| match e {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    eprintln!("Error walking path: {}", err);
+                    None
+                }
+            })
             .filter(is_sql)
     });
 
@@ -107,8 +113,14 @@ fn is_sql(entry: &DirEntry) -> bool {
 
 fn analyse_sql(sql: &str) -> Vec<Diagnostic> {
     let mut parser = TsParser::new();
-    parser.set_language(&language()).unwrap();
-    let tree = parser.parse(sql, None).unwrap();
+    if let Err(e) = parser.set_language(&language()) {
+        eprintln!("Error loading BigQuery grammar: {}", e);
+        return Vec::new();
+    }
+    let Some(tree) = parser.parse(sql, None) else {
+        eprintln!("Error parsing SQL input");
+        return Vec::new();
+    };
 
     let mut diagnostics = Vec::new();
     diagnostics.extend(compare_table_suffix_with_subquery::check(&tree, sql));
@@ -120,6 +132,14 @@ fn analyse_sql(sql: &str) -> Vec<Diagnostic> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use std::fs::{self, File};
@@ -162,5 +182,54 @@ mod tests {
         diagnostics.extend(compare_table_suffix_with_subquery::check(&tree, &sql));
         diagnostics.extend(use_current_date::check(&tree, &sql));
         assert!(diagnostics.len() > 1);
+    }
+
+    #[test]
+    fn analyse_sql_empty_input_yields_no_diagnostics() {
+        assert!(analyse_sql("").is_empty());
+    }
+
+    #[test]
+    fn analyse_sql_clean_query_yields_no_diagnostics() {
+        // A plain, well-formed query with none of the linted anti-patterns.
+        assert!(analyse_sql("SELECT id, name FROM users").is_empty());
+    }
+
+    #[test]
+    fn analyse_sql_aggregates_multiple_rules_from_a_single_query() {
+        // Triggers both use_current_date and compare_table_suffix_with_subquery,
+        // proving analyse_sql fans a query out across every rule and merges results.
+        let sql = "SELECT CURRENT_DATE() AS d \
+                   FROM t \
+                   WHERE _TABLE_SUFFIX = (SELECT MAX(suffix) FROM u)";
+        let diagnostics = analyse_sql(sql);
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.to_string().contains("CURRENT_DATE")),
+            "expected a CURRENT_DATE diagnostic, got: {:?}",
+            diagnostics
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.to_string().contains("Full scan")),
+            "expected a full-scan diagnostic, got: {:?}",
+            diagnostics
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn analyse_sql_does_not_panic_on_garbage_input() {
+        // Unparseable input must degrade gracefully (no panic), not crash the tool.
+        let _ = analyse_sql("!@#$ not really ;; SQL (((");
+        let _ = analyse_sql("SELECT FROM WHERE");
     }
 }

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -26,9 +26,13 @@ fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Dia
         let text = get_node_text(&node, src);
 
         if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
-            let parent = node.parent().unwrap();
+            let Some(parent) = node.parent() else {
+                continue;
+            };
             let mut tc = parent.walk();
-            let right_operand = parent.children(&mut tc).last().unwrap();
+            let Some(right_operand) = parent.children(&mut tc).last() else {
+                continue;
+            };
             if parent.kind() == "binary_expression"
                 && right_operand.kind() == "select_subexpression"
             {
@@ -48,14 +52,19 @@ fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Di
         let text = get_node_text(&node, src);
 
         if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
-            let parent = node.parent().unwrap();
+            let Some(parent) = node.parent() else {
+                continue;
+            };
             if parent.kind() == "between_operator" {
                 let mut tc = parent.walk();
                 for c in parent.children(&mut tc) {
+                    let Some(first_child) = c.child(0) else {
+                        continue;
+                    };
                     if (c.kind() == "between_from" || c.kind() == "between_to")
-                        && c.child(0).unwrap().kind() == "select_subexpression"
+                        && first_child.kind() == "select_subexpression"
                     {
-                        let rg = c.child(0).unwrap().range();
+                        let rg = first_child.range();
                         return Some(new_full_scan_warning(
                             rg.start_point.row,
                             rg.start_point.column,
@@ -70,13 +79,21 @@ fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Di
 
 fn new_full_scan_warning(row: usize, col: usize) -> Diagnostic {
     Diagnostic::new(
-        row + 1,
-        col + 1,
+        row.saturating_add(1),
+        col.saturating_add(1),
         "Full scan will cause! Should not compare _TABLE_SUFFIX with subquery".to_string(),
     )
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
@@ -127,6 +144,45 @@ mod tests {
         for node in traverse(tree.walk(), Order::Pre) {
             if node.kind() == "where_clause" {
                 assert!(compared_with_subquery_in_between_expression(node, &sql).is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn binary_op_points_at_the_subquery_position() {
+        // The diagnostic must point at the offending subquery, not the WHERE
+        // clause. On this single-line query the subquery starts at the '('.
+        let sql = "SELECT x FROM t WHERE _TABLE_SUFFIX = (SELECT MAX(s) FROM u)";
+        let paren_col = sql.find('(').expect("query contains a subquery paren");
+        let tree = parse_sql(sql);
+
+        let mut checked = false;
+        for node in traverse(tree.walk(), Order::Pre) {
+            if node.kind() == "where_clause" {
+                let diagnostic = compared_with_subquery_in_binary_expression(node, sql)
+                    .expect("subquery comparison should be flagged");
+                // 1-based, and row 1 because the query is on a single line.
+                assert_eq!(diagnostic.row(), 1);
+                assert_eq!(diagnostic.col(), paren_col + 1);
+                checked = true;
+            }
+        }
+        assert!(checked, "a where_clause node should exist");
+    }
+
+    #[test]
+    fn does_not_panic_on_malformed_where_clause() {
+        // Truncated / malformed input must not panic the node-navigation logic.
+        for sql in [
+            "SELECT x FROM t WHERE _TABLE_SUFFIX",
+            "WHERE _TABLE_SUFFIX = (",
+        ] {
+            let tree = parse_sql(sql);
+            for node in traverse(tree.walk(), Order::Pre) {
+                if node.kind() == "where_clause" {
+                    let _ = compared_with_subquery_in_binary_expression(node, sql);
+                    let _ = compared_with_subquery_in_between_expression(node, sql);
+                }
             }
         }
     }

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -1,8 +1,13 @@
 use tree_sitter::Node;
 
-/// Extract text content from a tree-sitter node
+/// Extract text content from a tree-sitter node.
+///
+/// `sql` is a valid `&str`, and the node's byte range points into that same
+/// source, so `utf8_text` cannot actually fail here. We still avoid panicking:
+/// on the impossible error we fall back to an empty string, which yields no
+/// match downstream (a miss, never a false positive or a crash).
 pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
-    node.utf8_text(sql.as_bytes()).unwrap()
+    node.utf8_text(sql.as_bytes()).unwrap_or_default()
 }
 
 /// Find the first child node with the specified kind
@@ -46,6 +51,12 @@ pub fn is_function_name(node: &Node) -> bool {
 
 /// Parse SQL string into a tree-sitter tree (test helper)
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test code"
+)]
 pub fn parse_sql(sql: &str) -> tree_sitter::Tree {
     use tree_sitter::Parser as TsParser;
     use tree_sitter_sql_bigquery::language;
@@ -56,6 +67,14 @@ pub fn parse_sql(sql: &str) -> tree_sitter::Tree {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
 

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -75,8 +75,8 @@ fn check_select_expression(
             // Check if the identifier is in GROUP BY
             if !group_by_columns.contains(field_text) {
                 return Some(Diagnostic::new(
-                    node.start_position().row + 1,
-                    node.start_position().column + 1,
+                    node.start_position().row.saturating_add(1),
+                    node.start_position().column.saturating_add(1),
                     format!(
                         "Column '{}' must appear in the GROUP BY clause or be used in an aggregate function",
                         field_text
@@ -161,6 +161,14 @@ fn is_in_aggregate_function(node: &Node, sql: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -37,13 +37,21 @@ fn find_query_expr<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
 
 fn new_unnecessary_order_by_warning(order_by_node: &Node) -> Diagnostic {
     Diagnostic::new(
-        order_by_node.start_position().row + 1,
-        order_by_node.start_position().column + 1,
+        order_by_node.start_position().row.saturating_add(1),
+        order_by_node.start_position().column.saturating_add(1),
         "Unnecessary ORDER BY: This ORDER BY clause has no effect without LIMIT/OFFSET or in aggregate functions".to_string(),
     )
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/context.rs
+++ b/src/rules/unused_column_in_cte/context.rs
@@ -58,6 +58,14 @@ impl<'a> AnalysisContext<'a> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
 

--- a/src/rules/unused_column_in_cte/graph.rs
+++ b/src/rules/unused_column_in_cte/graph.rs
@@ -81,6 +81,14 @@ impl Default for DependencyGraph {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
 

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -53,6 +53,14 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/models.rs
+++ b/src/rules/unused_column_in_cte/models.rs
@@ -16,7 +16,10 @@ impl ColumnInfo {
     // Note: While this function could technically be declared as `const fn`,
     // it cannot be called in const contexts because it takes `String` parameters
     // which require non-const operations like `to_string()` to construct.
-    #[allow(clippy::missing_const_for_fn)]
+    #[allow(
+        clippy::missing_const_for_fn,
+        reason = "takes String params requiring non-const construction; cannot be const-called"
+    )]
     pub fn new(
         table_name: Option<String>,
         column_name: String,
@@ -28,8 +31,8 @@ impl ColumnInfo {
             table_name,
             column_name,
             original_column_name,
-            row: row + 1,
-            col: col + 1,
+            row: row.saturating_add(1),
+            col: col.saturating_add(1),
         }
     }
 }
@@ -58,6 +61,14 @@ impl Ord for ColumnInfo {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
 

--- a/src/rules/unused_column_in_cte/utils.rs
+++ b/src/rules/unused_column_in_cte/utils.rs
@@ -7,10 +7,15 @@ use crate::rules::helpers::{get_node_text, is_function_name};
 use super::context::AnalysisContext;
 use super::models::ColumnInfo;
 
-/// Extract CTE name from a CTE node
+/// Extract CTE name from a CTE node.
+///
+/// A well-formed CTE always has an `alias_name` field. On a malformed tree
+/// where it is missing we return an empty name rather than panicking; an empty
+/// CTE name simply fails to match downstream lookups.
 pub fn get_cte_name<'a>(cte_node: &Node, sql: &'a str) -> &'a str {
-    let alias_node = cte_node.child_by_field_name("alias_name").unwrap();
-    get_node_text(&alias_node, sql)
+    cte_node
+        .child_by_field_name("alias_name")
+        .map_or("", |alias_node| get_node_text(&alias_node, sql))
 }
 
 /// Extract column name from a potentially qualified column reference
@@ -129,8 +134,17 @@ pub fn extract_and_mark_fields(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
+    use crate::rules::helpers::parse_sql;
 
     #[test]
     fn test_extract_column_name() {
@@ -143,5 +157,67 @@ mod tests {
     fn test_extract_table_name() {
         assert_eq!(extract_table_name("table"), "table");
         assert_eq!(extract_table_name("schema.table"), "schema");
+    }
+
+    fn col(name: &str) -> ColumnInfo {
+        ColumnInfo::new(None, name.to_string(), None, 0, 0)
+    }
+
+    #[test]
+    fn find_original_table_resolves_alias_to_real_table() {
+        let tables = vec!["orders".to_string()];
+        let mut alias_map = HashMap::new();
+        alias_map.insert("o".to_string(), "orders".to_string());
+        let cte_columns = HashMap::new();
+
+        assert_eq!(
+            find_original_table("o.id", &tables, &alias_map, &cte_columns),
+            "orders"
+        );
+    }
+
+    #[test]
+    fn find_original_table_uses_qualified_table_directly() {
+        let tables = vec!["users".to_string()];
+        let alias_map = HashMap::new();
+        let cte_columns = HashMap::new();
+
+        assert_eq!(
+            find_original_table("users.id", &tables, &alias_map, &cte_columns),
+            "users"
+        );
+    }
+
+    #[test]
+    fn find_original_table_matches_unqualified_column_against_cte() {
+        let tables = vec!["cte_a".to_string()];
+        let alias_map = HashMap::new();
+        let mut cte_columns = HashMap::new();
+        cte_columns.insert("cte_a".to_string(), vec![col("name"), col("email")]);
+
+        assert_eq!(
+            find_original_table("email", &tables, &alias_map, &cte_columns),
+            "cte_a"
+        );
+    }
+
+    #[test]
+    fn find_original_table_returns_empty_when_nothing_matches() {
+        let tables: Vec<String> = Vec::new();
+        let alias_map = HashMap::new();
+        let cte_columns = HashMap::new();
+
+        assert_eq!(
+            find_original_table("z.x", &tables, &alias_map, &cte_columns),
+            ""
+        );
+    }
+
+    #[test]
+    fn get_cte_name_is_empty_for_a_node_without_alias() {
+        // A non-CTE node has no `alias_name` field: we must get "" and not panic.
+        let sql = "SELECT 1";
+        let tree = parse_sql(sql);
+        assert_eq!(get_cte_name(&tree.root_node(), sql), "");
     }
 }

--- a/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
@@ -164,8 +164,8 @@ fn expand_asterisk(
             for col in cols {
                 let mut cloned_col = col.clone();
                 cloned_col.table_name = Some(cte_name.clone());
-                cloned_col.row = position.row + 1;
-                cloned_col.col = position.column + 1;
+                cloned_col.row = position.row.saturating_add(1);
+                cloned_col.col = position.column.saturating_add(1);
                 expanded_columns.push(cloned_col);
             }
         }
@@ -174,6 +174,14 @@ fn expand_asterisk(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
@@ -50,6 +50,14 @@ fn find_tables_for_pivot(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
@@ -32,6 +32,14 @@ impl NodeVisitor for QualifyVisitor {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/visitors/select_star_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_star_visitor.rs
@@ -62,6 +62,14 @@ fn mark_source_columns_as_used(select_list: &Node, context: &mut AnalysisContext
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/visitors/select_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_visitor.rs
@@ -297,6 +297,14 @@ fn mark_used_columns(context: &mut AnalysisContext, final_columns: Vec<ColumnInf
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/unused_column_in_cte/visitors/where_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/where_visitor.rs
@@ -164,6 +164,14 @@ fn extract_columns_from_condition(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -29,10 +29,22 @@ fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {
 }
 
 fn new_current_date_warning(row: usize, col: usize) -> Diagnostic {
-    Diagnostic::new(row + 1, col + 1, "CURRENT_DATE is used!".to_string())
+    Diagnostic::new(
+        row.saturating_add(1),
+        col.saturating_add(1),
+        "CURRENT_DATE is used!".to_string(),
+    )
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
@@ -64,5 +76,37 @@ mod tests {
             }
         }
         assert!(ds.is_empty());
+    }
+
+    #[test]
+    fn check_flags_every_occurrence() {
+        // Two calls on one line -> two diagnostics, each pointing at its own column.
+        let sql = "SELECT CURRENT_DATE(), CURRENT_DATE() FROM t";
+        let tree = parse_sql(sql);
+
+        let diagnostics = check(&tree, sql);
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics.iter().all(|d| d.row() == 1));
+
+        let expected_cols: Vec<usize> = sql
+            .match_indices("CURRENT_DATE")
+            .map(|(i, _)| i + 1)
+            .collect();
+        assert_eq!(expected_cols.len(), 2);
+        let cols: Vec<usize> = diagnostics.iter().map(Diagnostic::col).collect();
+        for expected in expected_cols {
+            assert!(
+                cols.contains(&expected),
+                "missing diagnostic at col {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn check_is_case_insensitive() {
+        // Lowercase spelling must be flagged just like the canonical uppercase.
+        let sql = "SELECT current_date() FROM t";
+        let tree = parse_sql(sql);
+        assert_eq!(check(&tree, sql).len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Applies a hardening pass over the linter's non-test code and backfills tests
for previously uncovered high-risk paths. No rule behavior changes for valid
input; the focus is failing loudly at build time and degrading gracefully at
runtime instead of panicking.

## Hardening

- Remove all hidden panics in non-test code (8 sites): the shared
  `get_node_text` helper, the `_TABLE_SUFFIX` node-navigation `unwrap()`s,
  `get_cte_name`, and `analyse_sql`'s parser setup/parse. Failures now skip
  gracefully or return early instead of aborting the process.
- Replace bare `row/col + 1` coordinate arithmetic with `saturating_add(1)`
  (13 sites).
- Log and skip `WalkDir` entry errors instead of silently dropping them.
- Add a `[lints]` gate (deny `unwrap_used`, `panic`, `indexing_slicing`,
  `arithmetic_side_effects`, `as_conversions`, …) and `overflow-checks = true`
  so these regressions are caught by CI going forward. Test/bench code opts out
  with scoped `#[allow(..., reason = "test code")]`.

## Tests

- `analyse_sql` entry point: empty input, clean query, multi-rule aggregation,
  and no-panic on garbage input.
- `Diagnostic` `Display` and accessors.
- `compare_table_suffix_with_subquery`: diagnostic row/col oracle + malformed
  input no-panic.
- `use_current_date`: every-occurrence counting and case-insensitivity.
- `find_original_table` alias/CTE resolution and `get_cte_name` on a node
  without an alias.

Verified that circular CTE references terminate (not an infinite loop), so no
guard was needed there.