### PR TITLE
refactor: introduce Rule trait + registry with single-pass traversal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,5 @@
 use bqvalid::diagnostic::Diagnostic;
-use bqvalid::rules::compare_table_suffix_with_subquery;
-use bqvalid::rules::invalid_group_by;
-use bqvalid::rules::unnecessary_order_by;
-use bqvalid::rules::unused_column_in_cte;
-use bqvalid::rules::use_current_date;
+use bqvalid::rules::run_rules;
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
 use log::debug;
@@ -172,13 +168,7 @@ fn analyse_sql(parser: &mut TsParser, sql: &str) -> Vec<Diagnostic> {
         return Vec::new();
     };
 
-    let mut diagnostics = Vec::new();
-    diagnostics.extend(compare_table_suffix_with_subquery::check(&tree, sql));
-    diagnostics.extend(invalid_group_by::check(&tree, sql));
-    diagnostics.extend(unnecessary_order_by::check(&tree, sql));
-    diagnostics.extend(unused_column_in_cte::check(&tree, sql));
-    diagnostics.extend(use_current_date::check(&tree, sql));
-    diagnostics
+    run_rules(&tree, sql)
 }
 
 #[cfg(test)]
@@ -235,9 +225,7 @@ mod tests {
             .unwrap();
         let tree = parser.parse(&sql, None).unwrap();
 
-        let mut diagnostics = Vec::new();
-        diagnostics.extend(compare_table_suffix_with_subquery::check(&tree, &sql));
-        diagnostics.extend(use_current_date::check(&tree, &sql));
+        let diagnostics = run_rules(&tree, &sql);
         assert!(diagnostics.len() > 1);
     }
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,6 +1,9 @@
 pub mod compare_table_suffix_with_subquery;
 pub mod helpers;
 pub mod invalid_group_by;
+pub mod rule;
 pub mod unnecessary_order_by;
 pub mod unused_column_in_cte;
 pub mod use_current_date;
+
+pub use rule::{Rule, all_rules, run_rules};

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -1,13 +1,19 @@
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
 use crate::rules::helpers::get_node_text;
+use crate::rules::rule::Rule;
 
-pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+/// Flags `_TABLE_SUFFIX` compared against a subquery, which forces a full scan.
+pub struct CompareTableSuffixWithSubquery;
 
-    for node in traverse(tree.walk(), Order::Pre) {
+impl Rule for CompareTableSuffixWithSubquery {
+    fn id(&self) -> &'static str {
+        "compare_table_suffix_with_subquery"
+    }
+
+    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if node.kind() == "where_clause" {
             if let Some(diagnostic) = compared_with_subquery_in_binary_expression(node, sql) {
                 diagnostics.push(diagnostic);
@@ -17,8 +23,6 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
             }
         }
     }
-
-    diagnostics
 }
 
 fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Diagnostic> {

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -1,26 +1,27 @@
 use std::collections::HashSet;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
 use crate::rules::helpers::{find_child_of_kind, get_node_text, is_function_name};
+use crate::rules::rule::Rule;
 
-pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    find_invalid_group_by(tree, sql)
-}
+/// Flags SELECT columns that are neither grouped nor aggregated, which BigQuery
+/// rejects at runtime.
+pub struct InvalidGroupBy;
 
-fn find_invalid_group_by(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+impl Rule for InvalidGroupBy {
+    fn id(&self) -> &'static str {
+        "invalid_group_by"
+    }
 
-    for node in traverse(tree.walk(), Order::Pre) {
+    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if node.kind() == "select"
             && let Some(diags) = check_select(&node, sql)
         {
             diagnostics.extend(diags);
         }
     }
-
-    diagnostics
 }
 
 fn check_select(node: &Node, sql: &str) -> Option<Vec<Diagnostic>> {
@@ -185,7 +186,7 @@ mod tests {
         let sql = fs::read_to_string(format!("./sql/{}", filename)).unwrap();
         let tree = parse_sql(&sql);
 
-        let diagnostics = check(&tree, &sql);
+        let diagnostics = InvalidGroupBy.check(&tree, &sql);
         assert_eq!(
             diagnostics.len(),
             expected_count,
@@ -206,7 +207,7 @@ mod tests {
         let sql = fs::read_to_string(format!("./sql/{}", filename)).unwrap();
         let tree = parse_sql(&sql);
 
-        let diagnostics = check(&tree, &sql);
+        let diagnostics = InvalidGroupBy.check(&tree, &sql);
         assert!(
             diagnostics.is_empty(),
             "Expected no diagnostics for valid GROUP BY in {}",

--- a/src/rules/rule.rs
+++ b/src/rules/rule.rs
@@ -1,0 +1,158 @@
+use tree_sitter::{Node, Tree};
+use tree_sitter_traversal::{Order, traverse};
+
+use crate::diagnostic::Diagnostic;
+use crate::rules::{
+    compare_table_suffix_with_subquery::CompareTableSuffixWithSubquery,
+    invalid_group_by::InvalidGroupBy, unnecessary_order_by::UnnecessaryOrderBy,
+    unused_column_in_cte::UnusedColumnInCte, use_current_date::UseCurrentDate,
+};
+
+/// A single lint rule.
+///
+/// Rules come in two shapes. Most react to individual syntax nodes and
+/// implement [`Rule::check_node`], which the shared traversal in [`run_rules`]
+/// calls once per node so every rule sees the tree in a single pre-order pass.
+/// Rules that need cross-node analysis (e.g. tracking CTE columns across the
+/// whole query) instead implement [`Rule::check_tree`] and walk the tree
+/// themselves.
+pub trait Rule {
+    /// Stable identifier for the rule. Used to reference the rule in output and
+    /// (in the future) in configuration and inline suppression.
+    fn id(&self) -> &'static str;
+
+    /// React to a single node visited during the shared pre-order traversal.
+    /// Node-driven rules override this; the default does nothing so tree-driven
+    /// rules can ignore it.
+    fn check_node(&self, _node: Node<'_>, _sql: &str, _diagnostics: &mut Vec<Diagnostic>) {}
+
+    /// React to the whole tree, for rules that cannot be expressed per node.
+    /// The default does nothing so node-driven rules can ignore it.
+    fn check_tree(&self, _tree: &Tree, _sql: &str, _diagnostics: &mut Vec<Diagnostic>) {}
+
+    /// Run this rule alone over `tree`. Convenience for unit tests and callers
+    /// that want a single rule's diagnostics; [`run_rules`] shares one traversal
+    /// across every rule instead.
+    fn check(&self, tree: &Tree, sql: &str) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        for node in traverse(tree.walk(), Order::Pre) {
+            self.check_node(node, sql, &mut diagnostics);
+        }
+        self.check_tree(tree, sql, &mut diagnostics);
+        diagnostics
+    }
+}
+
+/// The registry of every enabled rule. This is the single place rules are wired
+/// in: adding a rule means adding one entry here rather than editing the
+/// analysis loop.
+pub fn all_rules() -> Vec<Box<dyn Rule>> {
+    vec![
+        Box::new(CompareTableSuffixWithSubquery),
+        Box::new(InvalidGroupBy),
+        Box::new(UnnecessaryOrderBy),
+        Box::new(UnusedColumnInCte),
+        Box::new(UseCurrentDate),
+    ]
+}
+
+/// Run all registered rules over `tree` in a single pre-order traversal.
+///
+/// Node-driven rules each inspect every node during the one shared pass, rather
+/// than each rule walking the whole tree on its own. Tree-driven rules run
+/// afterwards. Diagnostics come out in traversal order for the node-driven
+/// rules, followed by the tree-driven ones.
+pub fn run_rules(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
+    let rules = all_rules();
+    let mut diagnostics = Vec::new();
+
+    for node in traverse(tree.walk(), Order::Pre) {
+        for rule in &rules {
+            rule.check_node(node, sql, &mut diagnostics);
+        }
+    }
+    for rule in &rules {
+        rule.check_tree(tree, sql, &mut diagnostics);
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
+mod tests {
+    use super::*;
+    use crate::rules::helpers::parse_sql;
+    use std::collections::HashSet;
+
+    #[test]
+    fn all_rules_have_unique_non_empty_ids() {
+        let rules = all_rules();
+        assert_eq!(rules.len(), 5, "every rule must be registered");
+
+        let ids: HashSet<&str> = rules.iter().map(|r| r.id()).collect();
+        assert_eq!(ids.len(), rules.len(), "rule ids must be unique");
+        assert!(rules.iter().all(|r| !r.id().is_empty()), "ids must be set");
+    }
+
+    #[test]
+    fn run_rules_aggregates_multiple_rules_in_a_single_pass() {
+        // One query that trips two independent node-driven rules. run_rules must
+        // surface both from its single shared traversal.
+        let sql = "SELECT CURRENT_DATE() AS d \
+                   FROM t \
+                   WHERE _TABLE_SUFFIX = (SELECT MAX(suffix) FROM u)";
+        let tree = parse_sql(sql);
+        let diagnostics = run_rules(&tree, sql);
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message().contains("CURRENT_DATE")),
+            "expected a CURRENT_DATE diagnostic"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message().contains("Full scan")),
+            "expected a full-scan diagnostic"
+        );
+    }
+
+    #[test]
+    fn run_rules_matches_each_rules_own_output() {
+        // run_rules' single pass must produce exactly the union of what each rule
+        // produces on its own, so merging traversals changes performance, not
+        // behaviour.
+        let sql = "SELECT CURRENT_DATE() AS d \
+                   FROM t \
+                   WHERE _TABLE_SUFFIX = (SELECT MAX(suffix) FROM u)";
+        let tree = parse_sql(sql);
+
+        let combined: HashSet<String> = run_rules(&tree, sql)
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        let mut expected: HashSet<String> = HashSet::new();
+        for rule in all_rules() {
+            expected.extend(rule.check(&tree, sql).iter().map(ToString::to_string));
+        }
+
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn run_rules_on_clean_query_yields_nothing() {
+        let sql = "SELECT id, name FROM users";
+        let tree = parse_sql(sql);
+        assert!(run_rules(&tree, sql).is_empty());
+    }
+}

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -1,21 +1,25 @@
-use tree_sitter::{Node, Tree};
-use tree_sitter_traversal::{Order, traverse};
+use tree_sitter::Node;
 
 use crate::diagnostic::Diagnostic;
 use crate::rules::helpers::{find_child_of_kind, has_child_of_kind};
+use crate::rules::rule::Rule;
 
-pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+/// Flags `ORDER BY` in a CTE or subquery without `LIMIT`, where the sort has no
+/// effect and only wastes work.
+pub struct UnnecessaryOrderBy;
 
-    for node in traverse(tree.root_node().walk(), Order::Pre) {
+impl Rule for UnnecessaryOrderBy {
+    fn id(&self) -> &'static str {
+        "unnecessary_order_by"
+    }
+
+    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if matches!(node.kind(), "cte" | "select_subexpression")
             && let Some(diagnostic) = check_unnecessary_order_by_in_scope(&node, sql)
         {
             diagnostics.push(diagnostic);
         }
     }
-
-    diagnostics
 }
 
 fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<Diagnostic> {
@@ -65,7 +69,7 @@ mod tests {
         let sql = fs::read_to_string(sql_file).unwrap();
         let tree = parse_sql(&sql);
 
-        let diagnostics = check(&tree, &sql);
+        let diagnostics = UnnecessaryOrderBy.check(&tree, &sql);
         assert_eq!(diagnostics.len(), expected_count);
     }
 
@@ -74,7 +78,7 @@ mod tests {
         let sql = fs::read_to_string("./sql/valid_order_by_with_limit.sql").unwrap();
         let tree = parse_sql(&sql);
 
-        let diagnostics = check(&tree, &sql);
+        let diagnostics = UnnecessaryOrderBy.check(&tree, &sql);
         assert!(diagnostics.is_empty());
     }
 }

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -10,12 +10,30 @@ use tree_sitter::Tree;
 use tree_sitter_traversal::{Order, traverse};
 
 use crate::diagnostic::Diagnostic;
+use crate::rules::rule::Rule;
 
 use context::AnalysisContext;
 use visitor::NodeVisitor;
 use visitors::{
     CteVisitor, PivotVisitor, QualifyVisitor, SelectStarVisitor, SelectVisitor, WhereVisitor,
 };
+
+/// Flags columns defined in a CTE but never referenced afterwards.
+///
+/// This rule needs cross-node analysis (which CTE columns get used anywhere in
+/// the query), so it walks the tree itself via [`Rule::check_tree`] rather than
+/// reacting to individual nodes in the shared traversal.
+pub struct UnusedColumnInCte;
+
+impl Rule for UnusedColumnInCte {
+    fn id(&self) -> &'static str {
+        "unused_column_in_cte"
+    }
+
+    fn check_tree(&self, tree: &Tree, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+        diagnostics.extend(check(tree, sql));
+    }
+}
 
 pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     let mut context = AnalysisContext::new(sql);

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -1,19 +1,22 @@
-use tree_sitter::{Node, Tree};
-use tree_sitter_traversal::{Order, traverse};
+use tree_sitter::Node;
 
 use crate::diagnostic::Diagnostic;
 use crate::rules::helpers::get_node_text;
+use crate::rules::rule::Rule;
 
-pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+/// Flags `CURRENT_DATE`, which hurts query reproducibility.
+pub struct UseCurrentDate;
 
-    for node in traverse(tree.walk(), Order::Pre) {
+impl Rule for UseCurrentDate {
+    fn id(&self) -> &'static str {
+        "use_current_date"
+    }
+
+    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if let Some(diagnostic) = current_date_used(node, sql) {
             diagnostics.push(diagnostic);
         }
     }
-
-    diagnostics
 }
 
 fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {
@@ -55,13 +58,7 @@ mod tests {
         let sql = fs::read_to_string("./sql/current_date_is_used.sql").unwrap();
         let tree = parse_sql(&sql);
 
-        let mut ds = Vec::new();
-        for node in traverse(tree.walk(), Order::Pre) {
-            if let Some(diag) = current_date_used(node, &sql) {
-                ds.push(diag);
-            }
-        }
-        assert!(!ds.is_empty());
+        assert!(!UseCurrentDate.check(&tree, &sql).is_empty());
     }
 
     #[test]
@@ -69,13 +66,7 @@ mod tests {
         let sql = fs::read_to_string("./sql/sample.sql").unwrap();
         let tree = parse_sql(&sql);
 
-        let mut ds = Vec::new();
-        for node in traverse(tree.walk(), Order::Pre) {
-            if let Some(diag) = current_date_used(node, &sql) {
-                ds.push(diag);
-            }
-        }
-        assert!(ds.is_empty());
+        assert!(UseCurrentDate.check(&tree, &sql).is_empty());
     }
 
     #[test]
@@ -84,7 +75,7 @@ mod tests {
         let sql = "SELECT CURRENT_DATE(), CURRENT_DATE() FROM t";
         let tree = parse_sql(sql);
 
-        let diagnostics = check(&tree, sql);
+        let diagnostics = UseCurrentDate.check(&tree, sql);
         assert_eq!(diagnostics.len(), 2);
         assert!(diagnostics.iter().all(|d| d.row() == 1));
 
@@ -107,6 +98,6 @@ mod tests {
         // Lowercase spelling must be flagged just like the canonical uppercase.
         let sql = "SELECT current_date() FROM t";
         let tree = parse_sql(sql);
-        assert_eq!(check(&tree, sql).len(), 1);
+        assert_eq!(UseCurrentDate.check(&tree, sql).len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Refactors the rule layer to remove tight coupling and redundant AST traversals.

- Rules were hard-wired into `main.rs`. Introduces a `Rule` trait and
  an `all_rules()` registry so adding a rule means one entry, not editing the
  analysis loop.
- Removes the duplicated `for node in traverse(...) { if node.kind() == ... }`
  boilerplate from the node-driven rules.
- The five rules each walked the whole tree independently. `run_rules()`
  now shares a single pre-order traversal across all node-driven rules.

## Changes

- Add `src/rules/rule.rs`:
  - `trait Rule { id(); check_node(); check_tree(); check() }`
  - `all_rules() -> Vec<Box<dyn Rule>>` — the single rule registry
  - `run_rules(tree, sql)` — one shared traversal fanning each node out to every rule
- Convert the four node-driven rules to structs implementing `check_node`
  (`UseCurrentDate`, `CompareTableSuffixWithSubquery`, `UnnecessaryOrderBy`,
  `InvalidGroupBy`).
- `UnusedColumnInCte` keeps its cross-node analysis via `check_tree`
  (its internal multi-pass work is tracked separately as P4/P5).
- Simplify `main.rs::analyse_sql` to a single `run_rules(&tree, sql)` call.

## Behavior

No change in what is detected. `run_rules` produces exactly the union of each
rule's own output (covered by a new test). Diagnostic **ordering** changes from
"grouped by rule" to source-position order for node-driven rules, followed by
the tree-driven rule.