### PR TITLE
Add rule_id and severity to Diagnostic, centralize construction

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,17 +1,51 @@
 use std::fmt::Display;
 
+/// Severity of a diagnostic.
+///
+/// `Error` marks a query that BigQuery would reject at runtime; `Warning` marks
+/// a performance or maintainability problem that still runs. The human-readable
+/// output does not print the severity yet — it is stored so machine-readable
+/// formats and per-rule control can use it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Warning,
+    Error,
+}
+
 /// Represents a diagnostic, such as a full scan error.
 ///
 /// rows and columns are 1-based.
 pub struct Diagnostic {
+    rule_id: &'static str,
+    severity: Severity,
     row: usize,
     col: usize,
     message: String,
 }
 
 impl Diagnostic {
-    pub const fn new(row: usize, col: usize, message: String) -> Self {
-        Self { row, col, message }
+    pub const fn new(
+        rule_id: &'static str,
+        severity: Severity,
+        row: usize,
+        col: usize,
+        message: String,
+    ) -> Self {
+        Self {
+            rule_id,
+            severity,
+            row,
+            col,
+            message,
+        }
+    }
+
+    pub const fn rule_id(&self) -> &'static str {
+        self.rule_id
+    }
+
+    pub const fn severity(&self) -> Severity {
+        self.severity
     }
 
     pub fn message(&self) -> &str {
@@ -39,15 +73,25 @@ mod tests {
 
     #[test]
     fn accessors_return_the_constructed_values() {
-        let d = Diagnostic::new(3, 5, "boom".to_string());
+        let d = Diagnostic::new("some_rule", Severity::Warning, 3, 5, "boom".to_string());
+        assert_eq!(d.rule_id(), "some_rule");
+        assert_eq!(d.severity(), Severity::Warning);
         assert_eq!(d.row(), 3);
         assert_eq!(d.col(), 5);
         assert_eq!(d.message(), "boom");
     }
 
     #[test]
+    fn severity_is_preserved() {
+        let d = Diagnostic::new("some_rule", Severity::Error, 1, 1, "bad".to_string());
+        assert_eq!(d.severity(), Severity::Error);
+    }
+
+    #[test]
     fn display_formats_as_row_col_message() {
-        let d = Diagnostic::new(3, 5, "boom".to_string());
+        // The human-readable form stays row:col: message; severity/rule_id are not
+        // printed here so existing output and pipelines are unchanged.
+        let d = Diagnostic::new("some_rule", Severity::Warning, 3, 5, "boom".to_string());
         assert_eq!(format!("{}", d), "3:5: boom");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,7 @@ fn analyse_sql(parser: &mut TsParser, sql: &str) -> Vec<Diagnostic> {
 )]
 mod tests {
     use super::*;
+    use bqvalid::diagnostic::Severity;
     use std::fs::{self, File};
     use tempfile::tempdir;
 
@@ -352,8 +353,8 @@ mod tests {
     fn write_diagnostics_emits_each_diagnostic_to_the_writer() {
         // D5: lint results are the tool's normal output and must go to stdout.
         let diagnostics = vec![
-            Diagnostic::new(1, 1, "first".to_string()),
-            Diagnostic::new(2, 3, "second".to_string()),
+            Diagnostic::new("test_rule", Severity::Warning, 1, 1, "first".to_string()),
+            Diagnostic::new("test_rule", Severity::Warning, 2, 3, "second".to_string()),
         ];
         let mut out = Vec::new();
         write_diagnostics(&mut out, &diagnostics).unwrap();
@@ -371,7 +372,13 @@ mod tests {
         let results = vec![
             FileResult {
                 path: dir.path().join("good.sql"),
-                diagnostics: vec![Diagnostic::new(1, 8, "some warning".to_string())],
+                diagnostics: vec![Diagnostic::new(
+                    "test_rule",
+                    Severity::Warning,
+                    1,
+                    8,
+                    "some warning".to_string(),
+                )],
                 read_error: None,
             },
             FileResult {

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -1,16 +1,18 @@
 use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
-use crate::diagnostic::Diagnostic;
-use crate::rules::helpers::get_node_text;
+use crate::diagnostic::{Diagnostic, Severity};
+use crate::rules::helpers::{get_node_text, one_based_start};
 use crate::rules::rule::Rule;
+
+const RULE_ID: &str = "compare_table_suffix_with_subquery";
 
 /// Flags `_TABLE_SUFFIX` compared against a subquery, which forces a full scan.
 pub struct CompareTableSuffixWithSubquery;
 
 impl Rule for CompareTableSuffixWithSubquery {
     fn id(&self) -> &'static str {
-        "compare_table_suffix_with_subquery"
+        RULE_ID
     }
 
     fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
@@ -40,11 +42,7 @@ fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Dia
             if parent.kind() == "binary_expression"
                 && right_operand.kind() == "select_subexpression"
             {
-                let rg = right_operand.range();
-                return Some(new_full_scan_warning(
-                    rg.start_point.row,
-                    rg.start_point.column,
-                ));
+                return Some(new_full_scan_warning(&right_operand));
             }
         }
     }
@@ -68,11 +66,7 @@ fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Di
                     if (c.kind() == "between_from" || c.kind() == "between_to")
                         && first_child.kind() == "select_subexpression"
                     {
-                        let rg = first_child.range();
-                        return Some(new_full_scan_warning(
-                            rg.start_point.row,
-                            rg.start_point.column,
-                        ));
+                        return Some(new_full_scan_warning(&first_child));
                     }
                 }
             }
@@ -81,10 +75,15 @@ fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Di
     None
 }
 
-fn new_full_scan_warning(row: usize, col: usize) -> Diagnostic {
+/// Build the full-scan diagnostic pointing at `subquery_node`. Both the binary
+/// and BETWEEN paths report the same problem, so construction lives here.
+fn new_full_scan_warning(subquery_node: &Node) -> Diagnostic {
+    let (row, col) = one_based_start(subquery_node);
     Diagnostic::new(
-        row.saturating_add(1),
-        col.saturating_add(1),
+        RULE_ID,
+        Severity::Warning,
+        row,
+        col,
         "Full scan will cause! Should not compare _TABLE_SUFFIX with subquery".to_string(),
     )
 }

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -10,6 +10,15 @@ pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
     node.utf8_text(sql.as_bytes()).unwrap_or_default()
 }
 
+/// 1-based (row, col) of a node's start position.
+///
+/// tree-sitter reports positions as 0-based; diagnostics report them as 1-based.
+/// This centralizes that `+1` conversion so rules don't each repeat it.
+pub fn one_based_start(node: &Node) -> (usize, usize) {
+    let point = node.start_position();
+    (point.row.saturating_add(1), point.column.saturating_add(1))
+}
+
 /// Find the first child node with the specified kind
 pub fn find_child_of_kind<'a>(node: &'a Node<'a>, kind: &str) -> Option<Node<'a>> {
     node.named_children(&mut node.walk())
@@ -95,6 +104,25 @@ mod tests {
             }
         }
         assert!(found, "Should find at least one identifier");
+    }
+
+    #[test]
+    fn one_based_start_converts_zero_based_position() {
+        // The single identifier starts at row 0, col 7 (0-based) in tree-sitter;
+        // one_based_start must report it as (1, 8).
+        let sql = "SELECT col1 FROM t";
+        let tree = parse_sql(sql);
+
+        use tree_sitter_traversal::{Order, traverse};
+        let mut checked = false;
+        for node in traverse(tree.walk(), Order::Pre) {
+            if node.kind() == "identifier" && get_node_text(&node, sql) == "col1" {
+                assert_eq!(one_based_start(&node), (1, 8));
+                checked = true;
+                break;
+            }
+        }
+        assert!(checked, "expected to find the col1 identifier");
     }
 
     #[test]

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -2,9 +2,11 @@ use std::collections::HashSet;
 use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
-use crate::diagnostic::Diagnostic;
-use crate::rules::helpers::{find_child_of_kind, get_node_text, is_function_name};
+use crate::diagnostic::{Diagnostic, Severity};
+use crate::rules::helpers::{find_child_of_kind, get_node_text, is_function_name, one_based_start};
 use crate::rules::rule::Rule;
+
+const RULE_ID: &str = "invalid_group_by";
 
 /// Flags SELECT columns that are neither grouped nor aggregated, which BigQuery
 /// rejects at runtime.
@@ -12,7 +14,7 @@ pub struct InvalidGroupBy;
 
 impl Rule for InvalidGroupBy {
     fn id(&self) -> &'static str {
-        "invalid_group_by"
+        RULE_ID
     }
 
     fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
@@ -75,9 +77,12 @@ fn check_select_expression(
 
             // Check if the identifier is in GROUP BY
             if !group_by_columns.contains(field_text) {
+                let (row, col) = one_based_start(&node);
                 return Some(Diagnostic::new(
-                    node.start_position().row.saturating_add(1),
-                    node.start_position().column.saturating_add(1),
+                    RULE_ID,
+                    Severity::Error,
+                    row,
+                    col,
                     format!(
                         "Column '{}' must appear in the GROUP BY clause or be used in an aggregate function",
                         field_text

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -1,8 +1,10 @@
 use tree_sitter::Node;
 
-use crate::diagnostic::Diagnostic;
-use crate::rules::helpers::{find_child_of_kind, has_child_of_kind};
+use crate::diagnostic::{Diagnostic, Severity};
+use crate::rules::helpers::{find_child_of_kind, has_child_of_kind, one_based_start};
 use crate::rules::rule::Rule;
+
+const RULE_ID: &str = "unnecessary_order_by";
 
 /// Flags `ORDER BY` in a CTE or subquery without `LIMIT`, where the sort has no
 /// effect and only wastes work.
@@ -10,7 +12,7 @@ pub struct UnnecessaryOrderBy;
 
 impl Rule for UnnecessaryOrderBy {
     fn id(&self) -> &'static str {
-        "unnecessary_order_by"
+        RULE_ID
     }
 
     fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
@@ -28,7 +30,14 @@ fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<
     if !has_child_of_kind(&query_expr, "limit_clause")
         && let Some(order_by_node) = find_child_of_kind(&query_expr, "order_by_clause")
     {
-        return Some(new_unnecessary_order_by_warning(&order_by_node));
+        let (row, col) = one_based_start(&order_by_node);
+        return Some(Diagnostic::new(
+            RULE_ID,
+            Severity::Warning,
+            row,
+            col,
+            "Unnecessary ORDER BY: This ORDER BY clause has no effect without LIMIT/OFFSET or in aggregate functions".to_string(),
+        ));
     }
 
     None
@@ -37,14 +46,6 @@ fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<
 fn find_query_expr<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
     node.named_children(&mut node.walk())
         .find(|&child| child.kind() == "query_expr")
-}
-
-fn new_unnecessary_order_by_warning(order_by_node: &Node) -> Diagnostic {
-    Diagnostic::new(
-        order_by_node.start_position().row.saturating_add(1),
-        order_by_node.start_position().column.saturating_add(1),
-        "Unnecessary ORDER BY: This ORDER BY clause has no effect without LIMIT/OFFSET or in aggregate functions".to_string(),
-    )
 }
 
 #[cfg(test)]

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -9,7 +9,7 @@ mod visitors;
 use tree_sitter::Tree;
 use tree_sitter_traversal::{Order, traverse};
 
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::rule::Rule;
 
 use context::AnalysisContext;
@@ -17,6 +17,8 @@ use visitor::NodeVisitor;
 use visitors::{
     CteVisitor, PivotVisitor, QualifyVisitor, SelectStarVisitor, SelectVisitor, WhereVisitor,
 };
+
+const RULE_ID: &str = "unused_column_in_cte";
 
 /// Flags columns defined in a CTE but never referenced afterwards.
 ///
@@ -27,7 +29,7 @@ pub struct UnusedColumnInCte;
 
 impl Rule for UnusedColumnInCte {
     fn id(&self) -> &'static str {
-        "unused_column_in_cte"
+        RULE_ID
     }
 
     fn check_tree(&self, tree: &Tree, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
@@ -62,6 +64,8 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
         .into_iter()
         .map(|col| {
             Diagnostic::new(
+                RULE_ID,
+                Severity::Warning,
                 col.row,
                 col.col,
                 format!("Unused column: {}", col.column_name),

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -1,15 +1,17 @@
 use tree_sitter::Node;
 
-use crate::diagnostic::Diagnostic;
-use crate::rules::helpers::get_node_text;
+use crate::diagnostic::{Diagnostic, Severity};
+use crate::rules::helpers::{get_node_text, one_based_start};
 use crate::rules::rule::Rule;
+
+const RULE_ID: &str = "use_current_date";
 
 /// Flags `CURRENT_DATE`, which hurts query reproducibility.
 pub struct UseCurrentDate;
 
 impl Rule for UseCurrentDate {
     fn id(&self) -> &'static str {
-        "use_current_date"
+        RULE_ID
     }
 
     fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
@@ -23,20 +25,16 @@ fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {
     let text = get_node_text(&node, src);
 
     if node.kind() == "identifier" && text.eq_ignore_ascii_case("current_date") {
-        return Some(new_current_date_warning(
-            node.range().start_point.row,
-            node.range().start_point.column,
+        let (row, col) = one_based_start(&node);
+        return Some(Diagnostic::new(
+            RULE_ID,
+            Severity::Warning,
+            row,
+            col,
+            "CURRENT_DATE is used!".to_string(),
         ));
     }
     None
-}
-
-fn new_current_date_warning(row: usize, col: usize) -> Diagnostic {
-    Diagnostic::new(
-        row.saturating_add(1),
-        col.saturating_add(1),
-        "CURRENT_DATE is used!".to_string(),
-    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- `Diagnostic` data model (`diagnostic.rs`)
  - Add `Severity` enum (`Warning` / `Error`)
  - Add `rule_id: &'static str` and `severity: Severity` fields with accessors
  - `Display` stays `row:col: message` — human output and pipelines are unchanged; the new fields are groundwork for machine-readable output (e.g. `--format json`) and per-rule control
- Centralize construction
  - Extract the 0-based → 1-based position conversion into `helpers::one_based_start`, removing the `+1` boilerplate duplicated in every rule
  - Drop each rule's bespoke `new_*_warning()` in favor of
    `Diagnostic::new(RULE_ID, Severity::…, …)`
  - Each rule module now shares a single `const RULE_ID` between `id()` and its diagnostics to prevent drift
- **Severity assignment**: `invalid_group_by` → `Error` (BigQuery actually rejects the query); the other four rules → `Warning`