### PR TITLE
refactor(helpers): surface get_node_text extraction failures instead of swallowing them

### DIFF
--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -1,13 +1,31 @@
 use tree_sitter::Node;
 
+/// Extract text content from a tree-sitter node, if its byte range maps to
+/// valid UTF-8 within `sql`.
+///
+/// Returns `None` when extraction fails. In normal use `sql` is a valid `&str`
+/// and the node's byte range points into that same source, so this cannot fail;
+/// a `None` therefore signals a corrupted tree or a tree/source mismatch.
+pub fn try_get_node_text<'a>(node: &Node, sql: &'a str) -> Option<&'a str> {
+    node.utf8_text(sql.as_bytes()).ok()
+}
+
 /// Extract text content from a tree-sitter node.
 ///
-/// `sql` is a valid `&str`, and the node's byte range points into that same
-/// source, so `utf8_text` cannot actually fail here. We still avoid panicking:
-/// on the impossible error we fall back to an empty string, which yields no
-/// match downstream (a miss, never a false positive or a crash).
+/// On the (practically impossible) extraction failure this logs a warning and
+/// falls back to an empty string, which yields no match downstream (a miss,
+/// never a false positive or a crash). The log makes the resulting false
+/// negative detectable instead of silently swallowing the error.
 pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
-    node.utf8_text(sql.as_bytes()).unwrap_or_default()
+    try_get_node_text(node, sql).unwrap_or_else(|| {
+        let (row, col) = one_based_start(node);
+        log::warn!(
+            "failed to extract text for node (kind: {}) at {row}:{col}; \
+             falling back to empty string, which may hide a violation",
+            node.kind(),
+        );
+        ""
+    })
 }
 
 /// 1-based (row, col) of a node's start position.
@@ -104,6 +122,71 @@ mod tests {
             }
         }
         assert!(found, "Should find at least one identifier");
+    }
+
+    #[test]
+    fn try_get_node_text_returns_some_on_valid_source() {
+        let sql = "SELECT col1 FROM t";
+        let tree = parse_sql(sql);
+
+        use tree_sitter_traversal::{Order, traverse};
+        let mut checked = false;
+        for node in traverse(tree.walk(), Order::Pre) {
+            if node.kind() == "identifier" {
+                assert_eq!(try_get_node_text(&node, sql), Some("col1"));
+                checked = true;
+                break;
+            }
+        }
+        assert!(checked, "expected to find the col1 identifier");
+    }
+
+    #[test]
+    fn try_get_node_text_returns_none_when_range_splits_a_multibyte_char() {
+        // Simulate a corrupted tree / source mismatch: extract a node's byte
+        // range from a *different* source in which that range slices through a
+        // multibyte character, yielding invalid UTF-8. `utf8_text` then returns
+        // Err and `try_get_node_text` must report the failure as `None` instead
+        // of silently producing an empty string (a hidden false negative).
+        let sql = "SELECT col1 FROM t";
+        let tree = parse_sql(sql);
+
+        use tree_sitter_traversal::{Order, traverse};
+        let mut ident = None;
+        for node in traverse(tree.walk(), Order::Pre) {
+            if node.kind() == "identifier" {
+                ident = Some(node);
+                break;
+            }
+        }
+        let node = ident.expect("expected to find the col1 identifier");
+        // "col1" occupies bytes 7..11 in `sql`. Build a same-or-longer valid
+        // string in which byte 10 is the first byte of a 3-byte character, so
+        // that slicing 7..11 cuts it and produces invalid UTF-8.
+        let mismatched = "abcdefghijあ";
+        assert_eq!(node.start_byte(), 7);
+        assert_eq!(node.end_byte(), 11);
+        assert_eq!(try_get_node_text(&node, mismatched), None);
+    }
+
+    #[test]
+    fn get_node_text_falls_back_to_empty_string_on_failure() {
+        // The public helper keeps its `&str` signature and returns "" on the
+        // (logged) failure path, so downstream comparisons simply miss.
+        let sql = "SELECT col1 FROM t";
+        let tree = parse_sql(sql);
+
+        use tree_sitter_traversal::{Order, traverse};
+        let mut ident = None;
+        for node in traverse(tree.walk(), Order::Pre) {
+            if node.kind() == "identifier" {
+                ident = Some(node);
+                break;
+            }
+        }
+        let node = ident.expect("expected to find the col1 identifier");
+        let mismatched = "abcdefghijあ";
+        assert_eq!(get_node_text(&node, mismatched), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`get_node_text` swallowed errors via `unwrap_or_default()`, silently falling back to an empty string. 
On a broken AST or a tree/source mismatch this produced hidden false negatives (missed lint violations) with no signal.

## Changes

- Add `try_get_node_text(node, sql) -> Option<&str>`, returning `None` on extraction failure — a testable seam and an API for callers that want to handle failure explicitly.
- Route `get_node_text` through it: on failure, log a `warn!` (node `kind` and 1-based `row:col`) before falling back to `""`. The public `&str` signature is unchanged, so all 25 existing call sites are untouched.
- The empty-string fallback still yields a downstream miss (never a false positive or a crash), but is now detectable via logs.