### PR TITLE
refactor(unused_column_in_cte): memoize column resolution & dedupe traversals

### DIFF
--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::LazyLock;
 use tree_sitter::Node;
 use tree_sitter_traversal::{Order, traverse};
 
@@ -7,6 +8,53 @@ use crate::rules::helpers::{find_child_of_kind, get_node_text, is_function_name,
 use crate::rules::rule::Rule;
 
 const RULE_ID: &str = "invalid_group_by";
+
+/// BigQuery aggregate functions (uppercase, matched case-insensitively).
+///
+/// Reference: <https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions>
+static AGGREGATE_FUNCTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        // Standard aggregate functions
+        "ANY_VALUE",
+        "ARRAY_AGG",
+        "ARRAY_CONCAT_AGG",
+        "AVG",
+        "BIT_AND",
+        "BIT_OR",
+        "BIT_XOR",
+        "COUNT",
+        "COUNTIF",
+        "GROUPING",
+        "LOGICAL_AND",
+        "LOGICAL_OR",
+        "MAX",
+        "MAX_BY",
+        "MIN",
+        "MIN_BY",
+        "STRING_AGG",
+        "SUM",
+        // Approximate aggregate functions
+        "APPROX_COUNT_DISTINCT",
+        "APPROX_QUANTILES",
+        "APPROX_TOP_COUNT",
+        "APPROX_TOP_SUM",
+        // Statistical aggregate functions
+        "CORR",
+        "COVAR_POP",
+        "COVAR_SAMP",
+        "STDDEV",
+        "STDDEV_POP",
+        "STDDEV_SAMP",
+        "VAR_POP",
+        "VAR_SAMP",
+        "VARIANCE",
+        // Geography aggregate functions
+        "ST_CENTROID_AGG",
+        "ST_UNION_AGG",
+    ]
+    .into_iter()
+    .collect()
+});
 
 /// Flags SELECT columns that are neither grouped nor aggregated, which BigQuery
 /// rejects at runtime.
@@ -114,49 +162,7 @@ fn is_in_aggregate_function(node: &Node, sql: &str) -> bool {
         {
             let func_name = get_node_text(&func_node, sql);
 
-            // BigQuery aggregate functions (case-insensitive)
-            // Reference: https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions
-            let func_name_upper = func_name.to_uppercase();
-            if matches!(
-                func_name_upper.as_str(),
-                // Standard aggregate functions
-                "ANY_VALUE"
-                    | "ARRAY_AGG"
-                    | "ARRAY_CONCAT_AGG"
-                    | "AVG"
-                    | "BIT_AND"
-                    | "BIT_OR"
-                    | "BIT_XOR"
-                    | "COUNT"
-                    | "COUNTIF"
-                    | "GROUPING"
-                    | "LOGICAL_AND"
-                    | "LOGICAL_OR"
-                    | "MAX"
-                    | "MAX_BY"
-                    | "MIN"
-                    | "MIN_BY"
-                    | "STRING_AGG"
-                    | "SUM"
-                    // Approximate aggregate functions
-                    | "APPROX_COUNT_DISTINCT"
-                    | "APPROX_QUANTILES"
-                    | "APPROX_TOP_COUNT"
-                    | "APPROX_TOP_SUM"
-                    // Statistical aggregate functions
-                    | "CORR"
-                    | "COVAR_POP"
-                    | "COVAR_SAMP"
-                    | "STDDEV"
-                    | "STDDEV_POP"
-                    | "STDDEV_SAMP"
-                    | "VAR_POP"
-                    | "VAR_SAMP"
-                    | "VARIANCE"
-                    // Geography aggregate functions
-                    | "ST_CENTROID_AGG"
-                    | "ST_UNION_AGG"
-            ) {
+            if AGGREGATE_FUNCTIONS.contains(func_name.to_uppercase().as_str()) {
                 return true;
             }
         }

--- a/src/rules/unused_column_in_cte/utils.rs
+++ b/src/rules/unused_column_in_cte/utils.rs
@@ -61,43 +61,119 @@ pub fn extract_table(from: Option<Node>, sql: &str) -> (Vec<String>, HashMap<Str
     (tables, alias_map)
 }
 
-/// Find the original table that a column belongs to
-pub fn find_original_table(
-    column: &str,
-    tables: &[String],
-    alias_map: &HashMap<String, String>,
-    cte_columns: &HashMap<String, Vec<ColumnInfo>>,
-) -> String {
-    // If column is qualified (e.g., "table1.column"), extract table name
-    if column.contains('.') {
-        let table_name = column.split('.').next().unwrap_or("");
-        // Check if this is an alias, and resolve it to the actual table name
-        let actual_table_name = alias_map
-            .get(table_name)
-            .map(|s| s.as_str())
-            .unwrap_or(table_name);
-        if tables.contains(&actual_table_name.to_string())
-            || cte_columns.contains_key(actual_table_name)
-        {
-            return actual_table_name.to_string();
+/// Resolves column references to their owning table within a single query scope
+/// (one FROM clause).
+///
+/// The unqualified-column lookup that [`find_original_table`] performs is
+/// `O(tables × columns_per_table)` per call, and each scope resolves many
+/// columns. `TableResolver` precomputes that mapping once so subsequent lookups
+/// are `O(1)`, while reproducing the exact resolution order of the original
+/// scan:
+/// - tables are considered in FROM order;
+/// - a table that is not a known CTE has unknown columns and therefore acts as
+///   a wildcard that claims any column, short-circuiting every table after it;
+/// - among CTEs preceding that wildcard, the first to expose a column wins.
+pub struct TableResolver<'a> {
+    tables: &'a [String],
+    alias_map: &'a HashMap<String, String>,
+    // Derived from `cte_columns`, but owned so the resolver only borrows the
+    // (context-independent) FROM-clause data and can coexist with a mutable
+    // borrow of the analysis context at the call sites.
+    is_cte: std::collections::HashSet<String>,
+    /// base column name -> owning table, for CTEs before the first wildcard.
+    unqualified: HashMap<String, &'a str>,
+    /// first non-CTE table in FROM order, if any; claims otherwise-unmatched columns.
+    wildcard: Option<&'a str>,
+}
+
+impl<'a> TableResolver<'a> {
+    pub fn new(
+        tables: &'a [String],
+        alias_map: &'a HashMap<String, String>,
+        cte_columns: &HashMap<String, Vec<ColumnInfo>>,
+    ) -> Self {
+        let mut is_cte = std::collections::HashSet::new();
+        let mut unqualified: HashMap<String, &str> = HashMap::new();
+        let mut wildcard = None;
+
+        for key in cte_columns.keys() {
+            is_cte.insert(key.clone());
+        }
+
+        for table in tables {
+            match cte_columns.get(table) {
+                Some(columns) => {
+                    for column_info in columns {
+                        let base = extract_column_name(&column_info.column_name);
+                        // First table in FROM order wins on a collision.
+                        unqualified
+                            .entry(base.to_string())
+                            .or_insert(table.as_str());
+                    }
+                }
+                None => {
+                    // Unknown columns: this table claims everything not already
+                    // matched, and shadows all following tables.
+                    wildcard = Some(table.as_str());
+                    break;
+                }
+            }
+        }
+
+        Self {
+            tables,
+            alias_map,
+            is_cte,
+            unqualified,
+            wildcard,
         }
     }
 
-    // For unqualified columns, find by exact column name match
-    let column_base_name = extract_column_name(column);
-    for table in tables {
-        if let Some(columns) = cte_columns.get(table) {
-            for column_info in columns {
-                let col_base_name = extract_column_name(&column_info.column_name);
-                if col_base_name == column_base_name {
-                    return table.clone();
-                }
+    /// Find the original table that a column belongs to, or `""` if none.
+    pub fn resolve(&self, column: &str) -> String {
+        // If column is qualified (e.g., "table1.column"), try the table prefix.
+        if column.contains('.') {
+            let table_name = column.split('.').next().unwrap_or("");
+            // Resolve aliases to the actual table name.
+            let actual_table_name = self
+                .alias_map
+                .get(table_name)
+                .map(|s| s.as_str())
+                .unwrap_or(table_name);
+            if self.tables.iter().any(|t| t == actual_table_name)
+                || self.is_cte.contains(actual_table_name)
+            {
+                return actual_table_name.to_string();
             }
-        } else {
-            return table.clone();
         }
+
+        // For unqualified columns (or qualified ones with an unknown prefix),
+        // match by the trailing column name.
+        let base = extract_column_name(column);
+        if let Some(table) = self.unqualified.get(base) {
+            return (*table).to_string();
+        }
+        if let Some(wildcard) = self.wildcard {
+            return wildcard.to_string();
+        }
+        String::new()
     }
-    String::new()
+
+    /// Resolve using the more permissive rule that WHERE / JOIN / UNNEST column
+    /// references use: a qualified prefix is always taken (alias-resolved),
+    /// even when it names neither a known table nor a CTE. Unqualified columns
+    /// fall back to [`resolve`](Self::resolve).
+    pub fn resolve_qualified_or(&self, column: &str) -> String {
+        if column.contains('.') {
+            let prefix = column.split('.').next().unwrap_or("");
+            return self
+                .alias_map
+                .get(prefix)
+                .cloned()
+                .unwrap_or_else(|| prefix.to_string());
+        }
+        self.resolve(column)
+    }
 }
 
 /// Recursively extract all field/identifier references and mark them as used
@@ -105,8 +181,7 @@ pub fn find_original_table(
 pub fn extract_and_mark_fields(
     node: &Node,
     sql: &str,
-    tables: &[String],
-    alias_map: &HashMap<String, String>,
+    resolver: &TableResolver,
     context: &mut AnalysisContext,
 ) {
     // Process current node if it's a field, identifier, or input_column
@@ -120,7 +195,7 @@ pub fn extract_and_mark_fields(
         let col_name = extract_column_name(field_text);
 
         // Find which table this column belongs to
-        let table = find_original_table(field_text, tables, alias_map, &context.cte_columns);
+        let table = resolver.resolve(field_text);
 
         if !table.is_empty() {
             context.mark_used(&table, col_name);
@@ -129,7 +204,7 @@ pub fn extract_and_mark_fields(
 
     // Recursively process children
     for child in node.children(&mut node.walk()) {
-        extract_and_mark_fields(&child, sql, tables, alias_map, context);
+        extract_and_mark_fields(&child, sql, resolver, context);
     }
 }
 
@@ -145,6 +220,16 @@ pub fn extract_and_mark_fields(
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
+
+    /// Test helper: resolve a single column via a one-shot [`TableResolver`].
+    fn find_original_table(
+        column: &str,
+        tables: &[String],
+        alias_map: &HashMap<String, String>,
+        cte_columns: &HashMap<String, Vec<ColumnInfo>>,
+    ) -> String {
+        TableResolver::new(tables, alias_map, cte_columns).resolve(column)
+    }
 
     #[test]
     fn test_extract_column_name() {
@@ -210,6 +295,101 @@ mod tests {
         assert_eq!(
             find_original_table("z.x", &tables, &alias_map, &cte_columns),
             ""
+        );
+    }
+
+    // The following tests lock the order-dependent quirks of resolution so the
+    // memoized implementation stays behaviourally identical.
+
+    #[test]
+    fn find_original_table_treats_non_cte_table_as_wildcard() {
+        // A table that is not a known CTE has unknown columns, so *any*
+        // unqualified column is attributed to it.
+        let tables = vec!["physical".to_string()];
+        let alias_map = HashMap::new();
+        let cte_columns = HashMap::new();
+
+        assert_eq!(
+            find_original_table("anything", &tables, &alias_map, &cte_columns),
+            "physical"
+        );
+    }
+
+    #[test]
+    fn find_original_table_prefers_first_cte_on_column_collision() {
+        // When two CTEs both expose the column, the first table in FROM wins.
+        let tables = vec!["a".to_string(), "b".to_string()];
+        let alias_map = HashMap::new();
+        let mut cte_columns = HashMap::new();
+        cte_columns.insert("a".to_string(), vec![col("x")]);
+        cte_columns.insert("b".to_string(), vec![col("x")]);
+
+        assert_eq!(
+            find_original_table("x", &tables, &alias_map, &cte_columns),
+            "a"
+        );
+    }
+
+    #[test]
+    fn find_original_table_falls_through_to_later_cte_without_match() {
+        let tables = vec!["a".to_string(), "b".to_string()];
+        let alias_map = HashMap::new();
+        let mut cte_columns = HashMap::new();
+        cte_columns.insert("a".to_string(), vec![col("p")]);
+        cte_columns.insert("b".to_string(), vec![col("x")]);
+
+        assert_eq!(
+            find_original_table("x", &tables, &alias_map, &cte_columns),
+            "b"
+        );
+    }
+
+    #[test]
+    fn find_original_table_wildcard_shadows_following_tables() {
+        // A non-CTE table appearing before a CTE short-circuits resolution:
+        // the non-CTE table is returned even for a column the later CTE owns.
+        let tables = vec!["physical".to_string(), "cte_b".to_string()];
+        let alias_map = HashMap::new();
+        let mut cte_columns = HashMap::new();
+        cte_columns.insert("cte_b".to_string(), vec![col("x")]);
+
+        assert_eq!(
+            find_original_table("x", &tables, &alias_map, &cte_columns),
+            "physical"
+        );
+    }
+
+    #[test]
+    fn find_original_table_cte_takes_precedence_over_following_wildcard() {
+        let tables = vec!["cte_a".to_string(), "physical".to_string()];
+        let alias_map = HashMap::new();
+        let mut cte_columns = HashMap::new();
+        cte_columns.insert("cte_a".to_string(), vec![col("x")]);
+
+        // Column owned by the CTE resolves to the CTE...
+        assert_eq!(
+            find_original_table("x", &tables, &alias_map, &cte_columns),
+            "cte_a"
+        );
+        // ...but an unknown column falls through to the wildcard table.
+        assert_eq!(
+            find_original_table("y", &tables, &alias_map, &cte_columns),
+            "physical"
+        );
+    }
+
+    #[test]
+    fn find_original_table_falls_through_when_qualifier_is_unknown() {
+        // Qualified reference whose prefix is neither a table nor an alias:
+        // resolution falls back to matching the trailing column name.
+        let tables = vec!["cte_a".to_string()];
+        let alias_map = HashMap::new();
+        let mut cte_columns = HashMap::new();
+        cte_columns.insert("cte_a".to_string(), vec![col("x")]);
+
+        assert_eq!(
+            find_original_table("unknown.x", &tables, &alias_map, &cte_columns),
+            "cte_a"
         );
     }
 

--- a/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
@@ -45,7 +45,10 @@ impl NodeVisitor for CteVisitor {
     }
 }
 
-/// Extract columns from a select_list node
+/// Extract columns from a select_list node.
+///
+/// Callers always pass the CTE's `select_list`, so this handles that node
+/// directly rather than recursing.
 fn extract_columns(
     node: &Node,
     sql: &str,
@@ -53,30 +56,22 @@ fn extract_columns(
 ) -> Vec<ColumnInfo> {
     let mut columns = Vec::new();
 
-    if node.kind() == "select_list" {
-        let from = node.next_named_sibling();
-        let (tables, alias_map) = utils::extract_table(from, sql);
-
-        for child in node.children(&mut node.walk()) {
-            if child.kind() == "select_expression" {
-                let column_info = extract_column_info_from_select_expression(
-                    &child,
-                    sql,
-                    &tables,
-                    &alias_map,
-                    cte_columns,
-                );
-                columns.push(column_info);
-            } else if child.kind() == "select_all" {
-                let position = child.start_position();
-                columns.extend(expand_asterisk(position, &tables, cte_columns));
-            }
-        }
+    if node.kind() != "select_list" {
         return columns;
     }
 
-    for child in node.named_children(&mut node.walk()) {
-        columns.extend(extract_columns(&child, sql, cte_columns));
+    let from = node.next_named_sibling();
+    let (tables, alias_map) = utils::extract_table(from, sql);
+    let resolver = utils::TableResolver::new(&tables, &alias_map, cte_columns);
+
+    for child in node.children(&mut node.walk()) {
+        if child.kind() == "select_expression" {
+            let column_info = extract_column_info_from_select_expression(&child, sql, &resolver);
+            columns.push(column_info);
+        } else if child.kind() == "select_all" {
+            let position = child.start_position();
+            columns.extend(expand_asterisk(position, &tables, cte_columns));
+        }
     }
 
     columns
@@ -86,9 +81,7 @@ fn extract_columns(
 fn extract_column_info_from_select_expression(
     select_expr: &Node,
     sql: &str,
-    tables: &[String],
-    alias_map: &std::collections::HashMap<String, String>,
-    cte_columns: &std::collections::HashMap<String, Vec<ColumnInfo>>,
+    resolver: &utils::TableResolver,
 ) -> ColumnInfo {
     // Check if there's an as_alias child
     let as_alias_node = select_expr
@@ -102,7 +95,7 @@ fn extract_column_info_from_select_expression(
     );
 
     // Resolve the table for this column
-    let table = utils::find_original_table(&original_column, tables, alias_map, cte_columns);
+    let table = resolver.resolve(&original_column);
 
     ColumnInfo::new(
         Some(table),

--- a/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
@@ -18,9 +18,10 @@ impl NodeVisitor for PivotVisitor {
         // Get the FROM clause to know which tables are available
         // Find the parent FROM clause
         let (tables, alias_map) = find_tables_for_pivot(node, sql);
+        let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
         // Extract all field/identifier references from the PIVOT clause
-        utils::extract_and_mark_fields(node, sql, &tables, &alias_map, context);
+        utils::extract_and_mark_fields(node, sql, &resolver, context);
     }
 }
 

--- a/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
@@ -25,9 +25,10 @@ impl NodeVisitor for QualifyVisitor {
             .named_children(&mut select_node.walk())
             .find(|child| child.kind() == "from_clause");
         let (tables, alias_map) = utils::extract_table(from_node, sql);
+        let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
         // Extract all field/identifier references from the QUALIFY clause
-        utils::extract_and_mark_fields(node, sql, &tables, &alias_map, context);
+        utils::extract_and_mark_fields(node, sql, &resolver, context);
     }
 }
 

--- a/src/rules/unused_column_in_cte/visitors/select_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_visitor.rs
@@ -75,12 +75,13 @@ fn extract_and_mark_expression_columns(
     // Get the FROM clause to know which tables are available
     let from = select_list.next_named_sibling();
     let (tables, alias_map) = utils::extract_table(from, sql);
+    let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
     // Process each select_expression
     for child in select_list.children(&mut select_list.walk()) {
         if child.kind() == "select_expression" {
             // Extract all field references from the expression (including nested ones in function calls)
-            extract_field_references_from_expression(&child, sql, &tables, &alias_map, context);
+            extract_field_references_from_expression(&child, sql, &resolver, context);
         }
     }
 }
@@ -106,8 +107,7 @@ fn find_parent_cte_name(select_node: &Node, sql: &str) -> String {
 fn extract_field_references_from_expression(
     node: &Node,
     sql: &str,
-    tables: &[String],
-    alias_map: &std::collections::HashMap<String, String>,
+    resolver: &utils::TableResolver,
     context: &mut AnalysisContext,
 ) {
     // Process current node if it's a field or identifier
@@ -120,7 +120,7 @@ fn extract_field_references_from_expression(
         let col_name = utils::extract_column_name(field_text);
 
         // Find which table this column belongs to
-        let table = utils::find_original_table(field_text, tables, alias_map, &context.cte_columns);
+        let table = resolver.resolve(field_text);
 
         if !table.is_empty() {
             context.mark_used(&table, col_name);
@@ -129,7 +129,7 @@ fn extract_field_references_from_expression(
 
     // Recursively process children
     for child in node.children(&mut node.walk()) {
-        extract_field_references_from_expression(&child, sql, tables, alias_map, context);
+        extract_field_references_from_expression(&child, sql, resolver, context);
     }
 }
 
@@ -143,6 +143,7 @@ fn extract_final_select_columns(
     let mut columns = Vec::new();
     let from = select_list.next_named_sibling();
     let (tables, alias_map) = utils::extract_table(from, sql);
+    let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
     for child in select_list.children(&mut select_list.walk()) {
         if child.kind() == "select_expression" {
@@ -160,12 +161,7 @@ fn extract_final_select_columns(
                 let column_text = get_node_text(&child, sql);
                 let col_name = utils::extract_column_name(column_text);
 
-                let table = utils::find_original_table(
-                    column_text,
-                    &tables,
-                    &alias_map,
-                    &context.cte_columns,
-                );
+                let table = resolver.resolve(column_text);
 
                 if !table.is_empty() {
                     columns.push(ColumnInfo::new(
@@ -179,14 +175,7 @@ fn extract_final_select_columns(
             }
 
             // Recurse to find any nested fields (after both branches)
-            extract_all_fields_into_vec(
-                &child,
-                sql,
-                &tables,
-                &alias_map,
-                &context.cte_columns,
-                &mut columns,
-            );
+            extract_all_fields_into_vec(&child, sql, &resolver, &mut columns);
         } else if child.kind() == "select_all" {
             // SELECT * - expand to all columns from referenced tables
             for table in &tables {
@@ -212,9 +201,7 @@ fn extract_final_select_columns(
 fn extract_all_fields_into_vec(
     node: &Node,
     sql: &str,
-    tables: &[String],
-    alias_map: &std::collections::HashMap<String, String>,
-    cte_columns: &std::collections::HashMap<String, Vec<ColumnInfo>>,
+    resolver: &utils::TableResolver,
     columns: &mut Vec<ColumnInfo>,
 ) {
     // Process current node if it's a field or identifier
@@ -229,7 +216,7 @@ fn extract_all_fields_into_vec(
         let col_name = utils::extract_column_name(field_text);
 
         // Find which table this column belongs to
-        let table = utils::find_original_table(field_text, tables, alias_map, cte_columns);
+        let table = resolver.resolve(field_text);
 
         if !table.is_empty() {
             columns.push(ColumnInfo::new(
@@ -244,7 +231,7 @@ fn extract_all_fields_into_vec(
 
     // Recursively process all children
     for child in node.children(&mut node.walk()) {
-        extract_all_fields_into_vec(&child, sql, tables, alias_map, cte_columns, columns);
+        extract_all_fields_into_vec(&child, sql, resolver, columns);
     }
 }
 

--- a/src/rules/unused_column_in_cte/visitors/where_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/where_visitor.rs
@@ -29,17 +29,11 @@ impl NodeVisitor for WhereVisitor {
 fn process_condition_node(node: &Node, context: &mut AnalysisContext) {
     let sql = context.sql();
     let (tables, alias_map) = extract_tables_from_parent(node, sql);
+    let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
     // Extract all column references from the condition
     let mut col_refs = Vec::new();
-    extract_columns_from_condition(
-        node,
-        sql,
-        &tables,
-        &alias_map,
-        &context.cte_columns,
-        &mut col_refs,
-    );
+    extract_columns_from_condition(node, sql, &resolver, &mut col_refs);
 
     // Mark each column reference as used
     for col_ref in col_refs {
@@ -65,6 +59,7 @@ fn extract_tables_from_parent(node: &Node, sql: &str) -> (Vec<String>, HashMap<S
 fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
     let sql = context.sql();
     let (tables, alias_map) = utils::extract_table(Some(*from_node), sql);
+    let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
     // Collect column references first
     let mut col_refs = Vec::new();
@@ -76,24 +71,7 @@ fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
             for unnest_child in traverse(child.walk(), Order::Pre) {
                 if unnest_child.kind() == "identifier" || unnest_child.kind() == "field" {
                     let column_text = get_node_text(&unnest_child, sql);
-
-                    // Resolve table name for this column
-                    let table = if column_text.contains('.') {
-                        // Qualified reference: table.column
-                        let prefix = column_text.split('.').next().unwrap_or("");
-                        alias_map
-                            .get(prefix)
-                            .cloned()
-                            .unwrap_or_else(|| prefix.to_string())
-                    } else {
-                        // Unqualified reference: find which table it belongs to
-                        utils::find_original_table(
-                            column_text,
-                            &tables,
-                            &alias_map,
-                            &context.cte_columns,
-                        )
-                    };
+                    let table = resolver.resolve_qualified_or(column_text);
 
                     if !table.is_empty() {
                         col_refs.push(ColumnInfo::new(
@@ -122,9 +100,7 @@ fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
 fn extract_columns_from_condition(
     node: &Node,
     sql: &str,
-    tables: &[String],
-    alias_map: &HashMap<String, String>,
-    cte_columns: &HashMap<String, Vec<ColumnInfo>>,
+    resolver: &utils::TableResolver,
     columns: &mut Vec<ColumnInfo>,
 ) {
     // Traverse the condition tree to find all column references
@@ -136,19 +112,7 @@ fn extract_columns_from_condition(
             }
 
             let column_text = get_node_text(&child, sql).to_string();
-
-            // Resolve table name for this column
-            let table = if column_text.contains('.') {
-                // Qualified reference: table.column
-                let prefix = column_text.split('.').next().unwrap_or("");
-                alias_map
-                    .get(prefix)
-                    .cloned()
-                    .unwrap_or_else(|| prefix.to_string())
-            } else {
-                // Unqualified reference: find which table it belongs to
-                utils::find_original_table(&column_text, tables, alias_map, cte_columns)
-            };
+            let table = resolver.resolve_qualified_or(&column_text);
 
             if !table.is_empty() {
                 columns.push(ColumnInfo::new(


### PR DESCRIPTION
## Summary

Behavior-preserving performance refactor of the two heaviest rules (`unused_column_in_cte`, `invalid_group_by`). 

## Changes

### memoize column resolution (`utils.rs`)
- Introduce `TableResolver`, built **once per query scope**, that precomputes a column → table index. Unqualified resolution drops from `O(N×M)` per call to `O(1)`; visitors reuse a resolver instead of calling `find_original_table` per node.
- Remove the stray `to_string()` allocation in the qualified-table check.
- The order-dependent quirks (non-CTE table acts as a wildcard that short-circuits following tables; first CTE wins on collision; unknown qualifier falls back to the trailing column name) are pinned by regression tests before the rewrite.

### dedupe traversals (visitors)
- Drop the dead recursive branch in `cte_visitor::extract_columns` (callers always pass a `select_list`).
- Collapse the duplicated qualifier-resolution logic in `where_visitor` into `TableResolver::resolve_qualified_or` — kept separate from `resolve` because WHERE/UNNEST references treat unknown qualifiers more permissively.

### aggregate lookup (`invalid_group_by.rs`)
- Move the 32 aggregate function names into a static `LazyLock<HashSet<&str>>` and replace the large `matches!` with a set lookup.