### PR TITLE
 refactor(tests): add run_rule helper and inline SQL literals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,11 +250,21 @@ mod tests {
         let mut parser = TsParser::new();
         parser.set_language(&language()).unwrap();
 
-        let sql = fs::read_to_string("./sql/current_date_and_subquery_with_between_are_used.sql")
-            .unwrap();
-        let tree = parser.parse(&sql, None).unwrap();
+        let sql = "\
+select
+  current_date,
+  column_a
+from
+  dataset.table
+where
+  _table_suffix between '2022-06-01'
+  and (
+    select dt from dates
+  )
+";
+        let tree = parser.parse(sql, None).unwrap();
 
-        let diagnostics = run_rules(&tree, &sql);
+        let diagnostics = run_rules(&tree, sql);
         assert!(diagnostics.len() > 1);
     }
 

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -100,53 +100,86 @@ fn new_full_scan_warning(subquery_node: &Node) -> Diagnostic {
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use std::fs;
 
     #[test]
     fn valid() {
-        let sql = fs::read_to_string("./sql/valid.sql").unwrap();
-        let tree = parse_sql(&sql);
+        let sql = "\
+select
+  *
+from
+  dataset.table
+";
+        let tree = parse_sql(sql);
 
         for node in traverse(tree.walk(), Order::Pre) {
             if node.kind() == "where_clause" {
-                assert!(compared_with_subquery_in_binary_expression(node, &sql).is_none());
-                assert!(compared_with_subquery_in_between_expression(node, &sql).is_none());
+                assert!(compared_with_subquery_in_binary_expression(node, sql).is_none());
+                assert!(compared_with_subquery_in_between_expression(node, sql).is_none());
             }
         }
     }
 
     #[test]
     fn binary_op() {
-        let sql = fs::read_to_string("./sql/subquery_with_binary_op.sql").unwrap();
-        let tree = parse_sql(&sql);
+        let sql = "\
+select
+  *
+from
+  dataset.table
+where
+  _table_suffix  = (
+    select dt from dates
+  )
+";
+        let tree = parse_sql(sql);
 
         for node in traverse(tree.walk(), Order::Pre) {
             if node.kind() == "where_clause" {
-                assert!(compared_with_subquery_in_binary_expression(node, &sql).is_some());
+                assert!(compared_with_subquery_in_binary_expression(node, sql).is_some());
             }
         }
     }
 
     #[test]
     fn between_from() {
-        let sql = fs::read_to_string("./sql/subquery_with_between_from.sql").unwrap();
-        let tree = parse_sql(&sql);
+        let sql = "\
+select
+  *
+from
+  dataset.table
+where
+  _table_suffix between (
+    select dt from dates
+  )
+  and '2022-06-01'
+";
+        let tree = parse_sql(sql);
 
         for node in traverse(tree.walk(), Order::Pre) {
             if node.kind() == "where_clause" {
-                assert!(compared_with_subquery_in_between_expression(node, &sql).is_some());
+                assert!(compared_with_subquery_in_between_expression(node, sql).is_some());
             }
         }
     }
 
     #[test]
     fn between_to() {
-        let sql = fs::read_to_string("./sql/subquery_with_between_to.sql").unwrap();
-        let tree = parse_sql(&sql);
+        let sql = "\
+select
+  *
+from
+  dataset.table
+where
+  _table_suffix between '2022-06-01'
+  and (
+    select dt from dates
+  )
+";
+        let tree = parse_sql(sql);
 
         for node in traverse(tree.walk(), Order::Pre) {
             if node.kind() == "where_clause" {
-                assert!(compared_with_subquery_in_between_expression(node, &sql).is_some());
+                assert!(compared_with_subquery_in_between_expression(node, sql).is_some());
             }
         }
     }

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -93,6 +93,20 @@ pub fn parse_sql(sql: &str) -> tree_sitter::Tree {
     parser.parse(sql, None).unwrap()
 }
 
+/// Parse `sql` and run a single rule over it, returning its diagnostics.
+///
+/// Collapses the repeated `parse_sql(...)` + `rule.check(&tree, sql)` boilerplate
+/// in rule tests so each case can pass an inline SQL literal and assert on the
+/// result directly.
+#[cfg(test)]
+pub fn run_rule<R: crate::rules::rule::Rule>(
+    rule: &R,
+    sql: &str,
+) -> Vec<crate::diagnostic::Diagnostic> {
+    let tree = parse_sql(sql);
+    rule.check(&tree, sql)
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -183,46 +183,165 @@ fn is_in_aggregate_function(node: &Node, sql: &str) -> bool {
 )]
 mod tests {
     use super::*;
-    use crate::rules::helpers::parse_sql;
+    use crate::rules::helpers::{parse_sql, run_rule};
     use rstest::rstest;
-    use std::fs;
 
     #[rstest]
-    #[case("invalid_group_by_column_not_in_clause.sql", 1)]
-    #[case("invalid_group_by_multiple_violations.sql", 2)]
-    #[case("invalid_group_by_in_subquery.sql", 1)]
-    #[case("invalid_group_by_qualified_column.sql", 1)]
-    #[case("invalid_group_by_mixed_qualified.sql", 1)]
-    fn test_invalid_group_by(#[case] filename: &str, #[case] expected_count: usize) {
-        let sql = fs::read_to_string(format!("./sql/{}", filename)).unwrap();
-        let tree = parse_sql(&sql);
-
-        let diagnostics = InvalidGroupBy.check(&tree, &sql);
+    // col2 is not in GROUP BY and not in an aggregate function
+    #[case(
+        "\
+SELECT col1, col2, COUNT(*) as cnt
+FROM my_table
+GROUP BY col1;
+",
+        1
+    )]
+    // Multiple columns not in GROUP BY
+    #[case(
+        "\
+SELECT col1, col2, col3, COUNT(*) as cnt
+FROM my_table
+GROUP BY col1;
+",
+        2
+    )]
+    // Invalid GROUP BY in subquery should be detected
+    #[case(
+        "\
+SELECT *
+FROM (
+  SELECT col1, col2, COUNT(*) as cnt
+  FROM my_table
+  GROUP BY col1
+) sub;
+",
+        1
+    )]
+    // Qualified column name not in GROUP BY
+    #[case(
+        "\
+SELECT t.col1, t.col2, COUNT(*) as cnt
+FROM my_table t
+GROUP BY t.col1;
+",
+        1
+    )]
+    // Mix of qualified and non-qualified columns; t1.col3 is not in GROUP BY
+    #[case(
+        "\
+SELECT t1.col1, col2, t1.col3, COUNT(*) as cnt
+FROM my_table t1
+GROUP BY t1.col1, col2;
+",
+        1
+    )]
+    fn test_invalid_group_by(#[case] sql: &str, #[case] expected_count: usize) {
+        let diagnostics = run_rule(&InvalidGroupBy, sql);
         assert_eq!(
             diagnostics.len(),
             expected_count,
-            "Expected {} diagnostic(s) in {}, got {}",
+            "Expected {} diagnostic(s), got {}",
             expected_count,
-            filename,
             diagnostics.len()
         );
     }
 
     #[rstest]
-    #[case("valid_group_by_with_aggregates.sql")]
-    #[case("valid_group_by_mixed_case_aggregates.sql")]
-    #[case("valid_group_by_all_aggregates.sql")]
-    #[case("valid_group_by_approx_functions.sql")]
-    #[case("valid_group_by_qualified_column.sql")]
-    fn test_valid_group_by(#[case] filename: &str) {
-        let sql = fs::read_to_string(format!("./sql/{}", filename)).unwrap();
-        let tree = parse_sql(&sql);
+    // All non-aggregated columns are in GROUP BY, multiple GROUP BY columns,
+    // and a query without GROUP BY (no violation).
+    #[case(
+        "\
+SELECT col1, COUNT(col2) as cnt, SUM(col3) as total
+FROM my_table
+GROUP BY col1;
 
-        let diagnostics = InvalidGroupBy.check(&tree, &sql);
+SELECT col1, col2, MAX(col3) as max_val
+FROM my_table
+GROUP BY col1, col2;
+
+SELECT col1, col2, col3
+FROM my_table;
+"
+    )]
+    // Mixed case aggregate functions should work
+    #[case(
+        "\
+SELECT col1, Count(col2) as cnt, SuM(col3) as total, mAx(col4) as max_val
+FROM my_table
+GROUP BY col1;
+"
+    )]
+    // All BigQuery aggregate functions
+    #[case(
+        "\
+SELECT
+  col1,
+  ANY_VALUE(col2) as any_val,
+  ARRAY_AGG(col3) as arr,
+  ARRAY_CONCAT_AGG(col4) as arr_concat,
+  AVG(col5) as avg_val,
+  BIT_AND(col6) as bit_and_val,
+  BIT_OR(col7) as bit_or_val,
+  BIT_XOR(col8) as bit_xor_val,
+  COUNT(col9) as cnt,
+  COUNTIF(col10 > 0) as cnt_if,
+  LOGICAL_AND(col11) as logical_and_val,
+  LOGICAL_OR(col12) as logical_or_val,
+  MAX(col13) as max_val,
+  MAX_BY(col14, col15) as max_by_val,
+  MIN(col16) as min_val,
+  MIN_BY(col17, col18) as min_by_val,
+  STRING_AGG(col19) as str_agg,
+  SUM(col20) as sum_val,
+  APPROX_COUNT_DISTINCT(col21) as approx_cnt,
+  APPROX_QUANTILES(col22, 4) as approx_quant,
+  APPROX_TOP_COUNT(col23, 10) as approx_top_cnt,
+  APPROX_TOP_SUM(col24, col25, 10) as approx_top_sum,
+  CORR(col26, col27) as corr_val,
+  COVAR_POP(col28, col29) as covar_pop_val,
+  COVAR_SAMP(col30, col31) as covar_samp_val,
+  STDDEV(col32) as stddev_val,
+  STDDEV_POP(col33) as stddev_pop_val,
+  STDDEV_SAMP(col34) as stddev_samp_val,
+  VAR_POP(col35) as var_pop_val,
+  VAR_SAMP(col36) as var_samp_val,
+  VARIANCE(col37) as variance_val
+FROM my_table
+GROUP BY col1;
+"
+    )]
+    // Approximate aggregate functions specifically
+    #[case(
+        "\
+SELECT
+  user_id,
+  APPROX_COUNT_DISTINCT(product_id) as unique_products,
+  APPROX_QUANTILES(price, 4) as price_quartiles,
+  APPROX_TOP_COUNT(category, 5) as top_categories,
+  APPROX_TOP_SUM(amount, item_name, 10) as top_items_by_amount
+FROM sales_table
+GROUP BY user_id;
+"
+    )]
+    // Qualified column names correctly used with GROUP BY, plus a join
+    #[case(
+        "\
+SELECT t.col1, t.col2, COUNT(t.col3) as cnt
+FROM my_table t
+GROUP BY t.col1, t.col2;
+
+SELECT t1.user_id, t2.category, COUNT(*) as cnt
+FROM users t1
+JOIN orders t2 ON t1.id = t2.user_id
+GROUP BY t1.user_id, t2.category;
+"
+    )]
+    fn test_valid_group_by(#[case] sql: &str) {
+        let diagnostics = run_rule(&InvalidGroupBy, sql);
         assert!(
             diagnostics.is_empty(),
-            "Expected no diagnostics for valid GROUP BY in {}",
-            filename
+            "Expected no diagnostics for valid GROUP BY, got {}",
+            diagnostics.len()
         );
     }
 

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -59,27 +59,91 @@ fn find_query_expr<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
 )]
 mod tests {
     use super::*;
-    use crate::rules::helpers::parse_sql;
+    use crate::rules::helpers::run_rule;
     use rstest::rstest;
-    use std::fs;
 
     #[rstest]
-    #[case("./sql/unnecessary_order_by_in_cte.sql", 1)]
-    #[case("./sql/unnecessary_order_by_in_subquery.sql", 1)]
-    fn test_unnecessary_order_by_exists(#[case] sql_file: &str, #[case] expected_count: usize) {
-        let sql = fs::read_to_string(sql_file).unwrap();
-        let tree = parse_sql(&sql);
-
-        let diagnostics = UnnecessaryOrderBy.check(&tree, &sql);
+    #[case(
+        "\
+-- Unnecessary ORDER BY in CTE
+with sorted_data as (
+  select
+    id,
+    name
+  from
+    table1
+  order by id  -- This ORDER BY is ignored
+)
+select
+  *
+from
+  sorted_data
+",
+        1
+    )]
+    #[case(
+        "\
+-- Unnecessary ORDER BY in subquery
+select
+  *
+from (
+  select
+    id,
+    name
+  from
+    table1
+  order by id  -- This ORDER BY is ignored
+)
+where
+  name = 'test'
+",
+        1
+    )]
+    fn test_unnecessary_order_by_exists(#[case] sql: &str, #[case] expected_count: usize) {
+        let diagnostics = run_rule(&UnnecessaryOrderBy, sql);
         assert_eq!(diagnostics.len(), expected_count);
     }
 
     #[test]
     fn test_valid_order_by_with_limit() {
-        let sql = fs::read_to_string("./sql/valid_order_by_with_limit.sql").unwrap();
-        let tree = parse_sql(&sql);
+        let sql = "\
+-- Valid: ORDER BY with LIMIT in CTE
+with top_users as (
+  select
+    id,
+    name
+  from
+    table1
+  order by id
+  limit 10
+)
+select
+  *
+from
+  top_users
 
-        let diagnostics = UnnecessaryOrderBy.check(&tree, &sql);
+-- Valid: ORDER BY with LIMIT in subquery
+select
+  *
+from (
+  select
+    id,
+    name
+  from
+    table1
+  order by id
+  limit 10
+)
+
+-- Valid: ORDER BY in final SELECT
+select
+  id,
+  name
+from
+  table1
+order by id
+";
+        let diagnostics = run_rule(&UnnecessaryOrderBy, sql);
         assert!(diagnostics.is_empty());
     }
 }

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -85,93 +85,691 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
 )]
 mod tests {
     use super::*;
-    use crate::rules::helpers::parse_sql;
+    use crate::rules::helpers::run_rule;
     use rstest::rstest;
-    use std::fs;
 
-    /// Integration tests using SQL files from sql/ directory
-    /// Each test case specifies the SQL file name and expected unused column names
+    /// Each case pairs an inline query with the column names expected to be
+    /// reported as unused.
     #[rstest]
-    #[case("unused_column_in_cte_simple.sql", vec!["unused_column1", "unused_column2"])]
-    #[case("unused_column_in_cte_column_alias.sql", vec!["column2", "unused_column"])]
-    #[case("unused_column_in_cte_function_argument.sql", vec!["unused_field"])]
-    #[case("unused_column_in_cte_join_only.sql", vec!["unused_field"])]
-    #[case("unused_column_in_cte_complex.sql", vec!["unused_field1", "unused_field2", "unused_amount_field", "unused_price_field", "another_unused"])]
-    #[case("unused_column_in_cte_multiple_alias.sql", vec!["email", "unused_field1", "unused_field2"])]
-    #[case("unused_column_in_cte_table_alias_without_as.sql", vec!["id", "name"])]
-    #[case("unused_column_in_cte_where_with_qualified_table.sql", vec!["contract_type", "base_fee", "account_fee", "free_account_count"])]
-    #[case("unused_column_in_cte_qualify.sql", vec!["unused_field"])]
-    #[case("unused_column_in_cte_select_star_with_unused.sql", vec!["unused_field1", "unused_field2"])]
-    #[case("unused_column_in_cte_select_star_multiple_joins.sql", vec!["id"])]
-    fn test_integration_with_sql_files(#[case] filename: &str, #[case] expected_unused: Vec<&str>) {
-        let sql_path = format!("sql/{}", filename);
-        let sql =
-            fs::read_to_string(&sql_path).unwrap_or_else(|_| panic!("Failed to read {}", sql_path));
+    #[case(
+        "\
+with data1 as (
+  select
+    column1,
+    column2,
+    unused_column1
+  from
+    table1
+), data2 as (
+  select
+    column3,
+    unused_column2
+  from
+    table2
+), data3 as (
+  select
+    column1,
+    column2,
+    column3
+  from
+    data1
+  left outer join
+    data2
+  on
+    data1.column1 = data2.column3
+)
+select
+  *
+from
+  data3
+",
+        vec!["unused_column1", "unused_column2"]
+    )]
+    // column1 is renamed to unique_id and used; column2 and unused_column are not.
+    #[case(
+        "\
+with
+  cte1 as (
+    select
+      column1 as unique_id,
+      column2,
+      unused_column
+    from
+      source_table
+  )
+select
+  unique_id,
+  count(*)
+from
+  cte1
+group by
+  unique_id
+",
+        vec!["column2", "unused_column"]
+    )]
+    // Columns used as window/aggregate function arguments are used; only
+    // unused_field is unused.
+    #[case(
+        "\
+with
+aggregated_data as (
+  select
+    category,
+    version,
+    unused_field,
+    count(1) as user_count
+  from
+    source_table
+  group by
+    category,
+    version
+),
+cumulative_data as (
+  select
+    category,
+    version,
+    user_count,
+    sum(user_count) over (
+      partition by category
+      order by version desc
+    ) as cumulative_count
+  from
+    aggregated_data
+),
+total_data as (
+  select
+    category,
+    sum(user_count) as total_count
+  from
+    cumulative_data
+  group by
+    category
+)
+select
+  cd.category,
+  cd.version,
+  cd.cumulative_count,
+  td.total_count
+from
+  cumulative_data cd
+  inner join total_data td on cd.category = td.category
+",
+        vec!["unused_field"]
+    )]
+    #[case(
+        "\
+with data1 as (
+  select
+    id,
+    name,
+    unused_field
+  from
+    table1
+), data2 as (
+  select
+    id,
+    amount
+  from
+    table2
+), joined_data as (
+  select
+    data1.name,
+    data2.amount
+  from
+    data1
+  inner join
+    data2
+  on
+    data1.id = data2.id
+)
+select
+  *
+from
+  joined_data
+",
+        vec!["unused_field"]
+    )]
+    #[case(
+        "\
+with data1 as (
+  select
+    id,
+    name,
+    unused_field1,
+    unused_field2
+  from
+    table1
+), data2 as (
+  select
+    id,
+    amount,
+    unused_amount_field
+  from
+    table2
+), data3 as (
+  select
+    id,
+    price,
+    unused_price_field,
+    another_unused
+  from
+    table3
+), joined_data as (
+  select
+    data1.id,
+    data1.name,
+    data2.amount,
+    data3.price
+  from
+    data1
+  inner join
+    data2
+  on
+    data1.id = data2.id
+  inner join
+    data3
+  on
+    data1.id = data3.id
+)
+select
+  *
+from
+  joined_data
+",
+        vec![
+            "unused_field1",
+            "unused_field2",
+            "unused_amount_field",
+            "unused_price_field",
+            "another_unused"
+        ]
+    )]
+    // Aliased columns traced through multiple CTEs.
+    #[case(
+        "\
+with
+  cte1 as (
+    select
+      id as user_id,
+      name as user_name,
+      email,
+      unused_field1
+    from
+      users_table
+  ),
+  cte2 as (
+    select
+      user_id as uid,
+      user_name,
+      unused_field2
+    from
+      cte1
+  )
+select
+  uid,
+  user_name
+from
+  cte2
+",
+        vec!["email", "unused_field1", "unused_field2"]
+    )]
+    // Table aliases without AS keyword; id and name are unused.
+    #[case(
+        "\
+with
+  source_data as (
+    select
+      id,
+      name,
+      category,
+      value
+    from
+      base_table
+  ),
+  filtered_data as (
+    select
+      category,
+      value
+    from
+      source_data sd
+  )
+select
+  fd.category,
+  fd.value
+from
+  filtered_data fd
+order by
+  category
+",
+        vec!["id", "name"]
+    )]
+    #[case(
+        "\
+with
+dim_contract as (
+  select distinct -- コメント
+    team_id
+    , start_date
+    , end_date
+    , contract_type
+    , base_fee
+    , account_fee
+    , free_account_count
+  from `project`.`dataset`.`dim_contract`
+  where
+    team_id is not null
+    and start_date is not null
+    and contract_type = '無償提供'
+)
 
-        let tree = parse_sql(&sql);
-        let diagnostics = check(&tree, &sql);
+select
+  team_id,
+  start_date,
+  end_date
+from
+  dim_contract
+",
+        vec!["contract_type", "base_fee", "account_fee", "free_account_count"]
+    )]
+    // Columns used in QUALIFY with SELECT * are used; only unused_field is unused.
+    #[case(
+        "\
+with
+  source_data as (
+    select
+      id,
+      category,
+      value,
+      unused_field
+    from
+      base_table
+  ),
+  merged_data as (
+    select
+      id,
+      category,
+      value,
+      concat(id, '-', category) as composite_key
+    from
+      source_data
+  ),
+  final as (
+    select
+      *
+    from
+      merged_data
+    qualify
+      row_number() over(partition by composite_key) = 1
+  )
+select
+  *
+from
+  final
+",
+        vec!["unused_field"]
+    )]
+    // select * from a joined table still reports the columns not selected downstream.
+    #[case(
+        "\
+with
+  table1 as (
+    select
+      id,
+      name,
+      age,
+      unused_field1
+    from
+      source_table1
+  ),
+  table2 as (
+    select
+      id,
+      email,
+      country,
+      unused_field2
+    from
+      source_table2
+  ),
+  joined_table as (
+    select
+      table1.id,
+      table1.name,
+      table1.age,
+      table2.email,
+      table2.country
+    from
+      table1
+      join table2 on table1.id = table2.id
+  )
+select
+  *
+from
+  joined_table
+",
+        vec!["unused_field1", "unused_field2"]
+    )]
+    // Columns used only in join conditions are used; id is unused.
+    #[case(
+        "\
+with
+  table1 as (
+    select
+      id,
+      name,
+      age,
+      department_id
+    from
+      source_table1
+  ),
+  table2 as (
+    select
+      id,
+      email,
+      country,
+      user_id
+    from
+      source_table2
+  ),
+  table3 as (
+    select
+      department_id,
+      department_name
+    from
+      source_table3
+  ),
+  joined_table as (
+    select
+      table1.id,
+      table1.name,
+      table1.age,
+      table2.email,
+      table2.country,
+      table3.department_name
+    from
+      table1
+      join table2 on table1.id = table2.user_id
+      join table3 on table1.department_id = table3.department_id
+  )
+select
+  *
+from
+  joined_table
+",
+        vec!["id"]
+    )]
+    fn test_integration_with_sql_files(#[case] sql: &str, #[case] expected_unused: Vec<&str>) {
+        let diagnostics = run_rule(&UnusedColumnInCte, sql);
 
-        if expected_unused.is_empty() {
-            assert!(
-                diagnostics.is_empty(),
-                "{}: Expected no unused columns, but found some",
-                filename
-            );
-        } else {
-            assert!(
-                !diagnostics.is_empty(),
-                "{}: Expected unused columns, but found none",
-                filename
-            );
+        assert!(
+            !diagnostics.is_empty(),
+            "Expected unused columns, but found none"
+        );
 
-            let mut found_columns: Vec<String> = diagnostics
-                .iter()
-                .map(|d| {
-                    // Extract column name from "Unused column: <name>" message
-                    d.message()
-                        .strip_prefix("Unused column: ")
-                        .unwrap_or(d.message())
-                        .to_string()
-                })
-                .collect();
+        let mut found_columns: Vec<String> = diagnostics
+            .iter()
+            .map(|d| {
+                // Extract column name from "Unused column: <name>" message
+                d.message()
+                    .strip_prefix("Unused column: ")
+                    .unwrap_or_else(|| d.message())
+                    .to_string()
+            })
+            .collect();
 
-            found_columns.sort();
-            let mut expected_sorted = expected_unused
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>();
-            expected_sorted.sort();
+        found_columns.sort();
+        let mut expected_sorted = expected_unused
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        expected_sorted.sort();
 
-            assert_eq!(
-                found_columns, expected_sorted,
-                "{}: Unused columns mismatch.\nExpected: {:?}\nFound: {:?}",
-                filename, expected_sorted, found_columns
-            );
-        }
+        assert_eq!(
+            found_columns, expected_sorted,
+            "Unused columns mismatch.\nExpected: {:?}\nFound: {:?}",
+            expected_sorted, found_columns
+        );
     }
 
-    /// Test cases that should report no unused columns
+    /// Queries that should report no unused columns.
     #[rstest]
-    #[case("unused_column_in_cte_aggregate_in_final_select.sql")]
-    #[case("unused_column_in_cte_join_where.sql")]
-    #[case("unused_column_in_cte_table_alias.sql")]
-    #[case("unused_column_in_cte_table_alias_join.sql")]
-    #[case("unused_column_in_cte_unnest_in_from.sql")]
-    #[case("unused_column_in_cte_pivot.sql")]
-    #[case("unused_column_in_cte_select_star_chain.sql")]
-    #[case("unused_column_in_cte_select_star_from_join.sql")]
-    fn test_integration_no_unused_columns(#[case] filename: &str) {
-        let sql_path = format!("sql/{}", filename);
-        let sql =
-            fs::read_to_string(&sql_path).unwrap_or_else(|_| panic!("Failed to read {}", sql_path));
-
-        let tree = parse_sql(&sql);
-        let diagnostics = check(&tree, &sql);
+    // active_count/inactive_count are used via sum() in the final SELECT.
+    #[case(
+        "\
+with base as (
+  select
+    user_id,
+    case
+      when status = 'active' then 1
+      else 0
+    end as active_count,
+    case
+      when status = 'inactive' then 1
+      else 0
+    end as inactive_count
+  from
+    users
+)
+select
+  user_id,
+  sum(active_count) as total_active,
+  sum(inactive_count) as total_inactive
+from
+  base
+group by
+  user_id
+"
+    )]
+    // Columns used only in JOIN/WHERE conditions are tracked as used.
+    #[case(
+        "\
+with
+  source_data as (
+    select
+      id,
+      company_id,
+      user_id,
+      name
+    from
+      base_table
+  ),
+  filtered_data as (
+    select
+      sd.id,
+      sd.name
+    from
+      source_data as sd
+    inner join
+      external_table as et
+    on
+      sd.company_id = et.company_id
+      and sd.user_id = et.user_id
+  )
+select
+  *
+from
+  filtered_data
+"
+    )]
+    #[case(
+        "\
+with
+  table1 as (
+    select
+      id,
+      name
+    from
+      source
+  ),
+  table2 as (
+    select
+      t1.id,
+      t1.name
+    from
+      table1 as t1
+  )
+select
+  *
+from
+  table2
+"
+    )]
+    // Table aliases with AS keyword used in JOIN conditions.
+    #[case(
+        "\
+with
+  orders as (
+    select
+      order_id,
+      customer_id,
+      order_date,
+      amount
+    from
+      order_source
+  ),
+  customers as (
+    select
+      customer_id,
+      customer_name,
+      region
+    from
+      customer_source
+  ),
+  result as (
+    select
+      ord.order_id,
+      ord.order_date,
+      ord.amount,
+      cust.customer_name,
+      cust.region
+    from
+      orders as ord
+      left join customers as cust on ord.customer_id = cust.customer_id
+  )
+select
+  *
+from
+  result
+"
+    )]
+    // date_array is used via unnest() in the final SELECT.
+    #[case(
+        "\
+with date_array_cte as (
+  select
+    user_id,
+    generate_date_array(start_date, end_date) as date_array
+  from
+    users
+)
+select
+  user_id,
+  date
+from
+  date_array_cte,
+  unnest(date_array) as date
+"
+    )]
+    // Columns used in PIVOT (aggregate arg and FOR clause) are used.
+    #[case(
+        "\
+with raw_data as (
+  select
+    category,
+    month,
+    value
+  from
+    source_table
+),
+pivoted as (
+  select
+    category,
+    jan,
+    feb,
+    mar
+  from
+    raw_data
+  pivot(
+    sum(value)
+    for month in ('Jan' as jan, 'Feb' as feb, 'Mar' as mar)
+  )
+)
+select * from pivoted
+"
+    )]
+    // SELECT * chained across CTEs tracks all columns as used.
+    #[case(
+        "\
+with
+  source_data as (
+    select
+      id,
+      name,
+      category,
+      created_at
+    from
+      base_table
+  ),
+  intermediate as (
+    select
+      *
+    from
+      source_data
+  ),
+  final_data as (
+    select
+      *
+    from
+      intermediate
+  )
+select
+  *
+from
+  final_data
+"
+    )]
+    // select * from a joined table uses all columns from both sides.
+    #[case(
+        "\
+with
+  table1 as (
+    select
+      id,
+      name,
+      age
+    from
+      source_table1
+  ),
+  table2 as (
+    select
+      id,
+      email,
+      country
+    from
+      source_table2
+  ),
+  joined_table as (
+    select
+      table1.id,
+      table1.name,
+      table1.age,
+      table2.email,
+      table2.country
+    from
+      table1
+      join table2 on table1.id = table2.id
+  )
+select
+  *
+from
+  joined_table
+"
+    )]
+    fn test_integration_no_unused_columns(#[case] sql: &str) {
+        let diagnostics = run_rule(&UnusedColumnInCte, sql);
 
         assert!(
             diagnostics.is_empty(),
-            "{}: Expected no unused columns, but found: {:?}",
-            filename,
+            "Expected no unused columns, but found: {:?}",
             diagnostics
                 .iter()
                 .map(|diag| diag.message().to_string())

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -48,32 +48,37 @@ fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {
 )]
 mod tests {
     use super::*;
-    use crate::rules::helpers::parse_sql;
-    use std::fs;
+    use crate::rules::helpers::run_rule;
 
     #[test]
     fn current_date_is_used() {
-        let sql = fs::read_to_string("./sql/current_date_is_used.sql").unwrap();
-        let tree = parse_sql(&sql);
-
-        assert!(!UseCurrentDate.check(&tree, &sql).is_empty());
+        let sql = "\
+select
+  current_date,
+  column_a
+from
+  dataset.table
+";
+        assert!(!run_rule(&UseCurrentDate, sql).is_empty());
     }
 
     #[test]
     fn current_date_is_not_used() {
-        let sql = fs::read_to_string("./sql/sample.sql").unwrap();
-        let tree = parse_sql(&sql);
-
-        assert!(UseCurrentDate.check(&tree, &sql).is_empty());
+        let sql = "\
+select
+  *
+from
+  dataset.table
+";
+        assert!(run_rule(&UseCurrentDate, sql).is_empty());
     }
 
     #[test]
     fn check_flags_every_occurrence() {
         // Two calls on one line -> two diagnostics, each pointing at its own column.
         let sql = "SELECT CURRENT_DATE(), CURRENT_DATE() FROM t";
-        let tree = parse_sql(sql);
 
-        let diagnostics = UseCurrentDate.check(&tree, sql);
+        let diagnostics = run_rule(&UseCurrentDate, sql);
         assert_eq!(diagnostics.len(), 2);
         assert!(diagnostics.iter().all(|d| d.row() == 1));
 
@@ -95,7 +100,6 @@ mod tests {
     fn check_is_case_insensitive() {
         // Lowercase spelling must be flagged just like the canonical uppercase.
         let sql = "SELECT current_date() FROM t";
-        let tree = parse_sql(sql);
-        assert_eq!(UseCurrentDate.check(&tree, sql).len(), 1);
+        assert_eq!(run_rule(&UseCurrentDate, sql).len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Addresses test setup duplication from the refactoring plan. Test modules previously repeated the `parse_sql(...)` + `rule.check(&tree, sql)` boilerplate and loaded SQL from hardcoded `./sql/*.sql` paths. This made tests indirect and coupled to on-disk fixtures, against the project's "no fixtures — keep test data in the test function" principle.

## Changes

- Add a `run_rule(rule, sql)` test helper in `helpers.rs` (`cfg(test)`) that parses `sql` and runs a single rule, returning its diagnostics.
- Replace `fs::read_to_string("./sql/…")` with inline SQL literals across all rule tests (`use_current_date`, `unnecessary_order_by`, `invalid_group_by`, `unused_column_in_cte`) and the `main.rs` integration test.
- Keep `parse_sql` + `traverse` in `compare_table_suffix_with_subquery` white-box tests (they assert on private helpers per node) and inline SQL only.
- Preserve `rstest` parameterization by passing SQL literals directly as `#[case(...)]` values.
- Fix an `unwrap_or` → `unwrap_or_else` lint surfaced under `--all-targets`.