### PR TITLE
feat(output): add --format flag for json and sarif output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,8 @@ dependencies = [
  "log",
  "rayon",
  "rstest",
+ "serde",
+ "serde_json",
  "tempfile",
  "tree-sitter",
  "tree-sitter-sql-bigquery",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.4.32"
 env_logger = "0.11.10"
 clap-verbosity-flag = "3.0.4"
 rayon = "1.12.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ one.sql:6:6: Full scan will cause! Should not compare _TABLE_SUFFIX with subquer
 three.sql:5:19: Full scan will cause! Should not compare _TABLE_SUFFIX with subquery
 ```
 
+### Output formats
+
+By default `bqvalid` prints the human-readable format shown above. Use `--format`
+to emit machine-readable output for CI and editor integrations:
+
+```shell
+bqvalid --format json sql/    # a single JSON document with a flat `diagnostics` array
+bqvalid --format sarif sql/   # SARIF 2.1.0, e.g. for GitHub code scanning
+```
+
+Lint diagnostics go to stdout; the tool's own errors (unreadable files, parse
+failures) go to stderr, so either format can be piped cleanly.
+
 ## Linting Rules
 
 See the [rules page](https://github.com/hirosassa/bqvalid/blob/main/docs/rules.md)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod diagnostic;
+pub mod output;
 pub mod rules;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use bqvalid::diagnostic::Diagnostic;
+use bqvalid::output::{self, FileDiagnostics, OutputFormat};
 use bqvalid::rules::run_rules;
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
@@ -29,6 +30,10 @@ fn get_version() -> &'static str {
 struct Args {
     files: Vec<String>,
 
+    /// Output format for diagnostics.
+    #[clap(long, value_enum, default_value_t = OutputFormat::Plain)]
+    format: OutputFormat,
+
     #[clap(flatten)]
     verbose: Verbosity,
 }
@@ -53,7 +58,18 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         };
         let diagnostics = analyse_sql(&mut parser, &sql);
-        if let Err(e) = write_diagnostics(&mut io::stdout().lock(), &diagnostics) {
+        let mut out = io::stdout().lock();
+        let write_result = match args.format {
+            OutputFormat::Plain => write_diagnostics(&mut out, &diagnostics),
+            OutputFormat::Json | OutputFormat::Sarif => {
+                let files = [FileDiagnostics {
+                    path: "<stdin>",
+                    diagnostics: &diagnostics,
+                }];
+                emit_machine(&mut out, args.format, get_version(), &files)
+            }
+        };
+        if let Err(e) = write_result {
             eprintln!("Error writing diagnostics: {}", e);
             return ExitCode::FAILURE;
         }
@@ -85,7 +101,16 @@ fn main() -> ExitCode {
 
     let results = analyse_paths(targets);
 
-    match report(&results, &mut io::stdout().lock(), &mut io::stderr().lock()) {
+    let mut out = io::stdout().lock();
+    let mut err = io::stderr().lock();
+    let write_result = match args.format {
+        OutputFormat::Plain => report(&results, &mut out, &mut err),
+        OutputFormat::Json | OutputFormat::Sarif => {
+            report_machine(&results, args.format, get_version(), &mut out, &mut err)
+        }
+    };
+
+    match write_result {
         Ok(true) => ExitCode::FAILURE,
         Ok(false) => ExitCode::SUCCESS,
         Err(e) => {
@@ -93,6 +118,67 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Emit `files` in the given machine-readable `format` to `out`. `Plain` is a
+/// no-op here — callers route it through `write_diagnostics`/`report` instead.
+fn emit_machine<W: Write>(
+    out: &mut W,
+    format: OutputFormat,
+    version: &str,
+    files: &[FileDiagnostics],
+) -> io::Result<()> {
+    match format {
+        OutputFormat::Json => output::write_json(out, files),
+        OutputFormat::Sarif => output::write_sarif(out, files, version),
+        OutputFormat::Plain => Ok(()),
+    }
+}
+
+/// Render per-file results in a machine-readable format: the aggregated
+/// document goes to `out` (stdout), while the tool's own failures (unreadable
+/// files) still go to `err` (stderr). Returns `true` when any diagnostic or
+/// read error was seen, so the caller can pick the exit code.
+fn report_machine<O: Write, E: Write>(
+    results: &[FileResult],
+    format: OutputFormat,
+    version: &str,
+    out: &mut O,
+    err: &mut E,
+) -> io::Result<bool> {
+    let mut has_problem = false;
+    for result in results {
+        if let Some(read_error) = &result.read_error {
+            writeln!(
+                err,
+                "{}: Error reading file: {}",
+                result.path.display(),
+                read_error
+            )?;
+            has_problem = true;
+        }
+        if !result.diagnostics.is_empty() {
+            has_problem = true;
+        }
+    }
+
+    // `path.display()` yields a temporary, so materialize the path strings first
+    // and borrow them into the format views.
+    let paths: Vec<String> = results
+        .iter()
+        .map(|r| r.path.display().to_string())
+        .collect();
+    let views: Vec<FileDiagnostics> = results
+        .iter()
+        .zip(&paths)
+        .map(|(r, path)| FileDiagnostics {
+            path,
+            diagnostics: &r.diagnostics,
+        })
+        .collect();
+
+    emit_machine(out, format, version, &views)?;
+    Ok(has_problem)
 }
 
 /// Write lint diagnostics (the tool's normal output) to `out`. Used for the
@@ -456,5 +542,102 @@ where
         assert_eq!(results[0].path, missing);
         assert!(results[0].read_error.is_some());
         assert!(results[0].diagnostics.is_empty());
+    }
+
+    #[test]
+    fn report_machine_json_writes_document_to_stdout_and_read_errors_to_stderr() {
+        // A machine format aggregates diagnostics into a single JSON document on
+        // stdout; the tool's own read failure still goes to stderr so the two
+        // never mix on the same pipe.
+        let dir = tempdir().unwrap();
+        let results = vec![
+            FileResult {
+                path: dir.path().join("good.sql"),
+                diagnostics: vec![Diagnostic::new(
+                    "use_current_date",
+                    Severity::Warning,
+                    1,
+                    8,
+                    "some warning".to_string(),
+                )],
+                read_error: None,
+            },
+            FileResult {
+                path: dir.path().join("missing.sql"),
+                diagnostics: Vec::new(),
+                read_error: Some("no such file".to_string()),
+            },
+        ];
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let has_problem =
+            report_machine(&results, OutputFormat::Json, "1.2.3", &mut out, &mut err).unwrap();
+
+        assert!(has_problem);
+        let doc: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let entries = doc["diagnostics"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["rule_id"], "use_current_date");
+        assert!(
+            entries[0]["path"].as_str().unwrap().ends_with("good.sql"),
+            "diagnostic must carry its file path"
+        );
+
+        let err = String::from_utf8(err).unwrap();
+        assert!(err.contains("Error reading file"));
+        assert!(
+            !err.contains("some warning"),
+            "diagnostics must not appear on stderr"
+        );
+    }
+
+    #[test]
+    fn report_machine_sarif_produces_a_2_1_0_run() {
+        let dir = tempdir().unwrap();
+        let results = vec![FileResult {
+            path: dir.path().join("a.sql"),
+            diagnostics: vec![Diagnostic::new(
+                "invalid_group_by",
+                Severity::Error,
+                5,
+                1,
+                "bad".to_string(),
+            )],
+            read_error: None,
+        }];
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let has_problem =
+            report_machine(&results, OutputFormat::Sarif, "1.2.3", &mut out, &mut err).unwrap();
+
+        assert!(has_problem);
+        let doc: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(doc["version"], "2.1.0");
+        let result = &doc["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "invalid_group_by");
+        assert_eq!(result["level"], "error");
+    }
+
+    #[test]
+    fn report_machine_flags_no_problem_for_clean_results() {
+        let dir = tempdir().unwrap();
+        let results = vec![FileResult {
+            path: dir.path().join("clean.sql"),
+            diagnostics: Vec::new(),
+            read_error: None,
+        }];
+
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let has_problem =
+            report_machine(&results, OutputFormat::Json, "1.2.3", &mut out, &mut err).unwrap();
+
+        assert!(!has_problem);
+        // Still a well-formed document, just with no diagnostics.
+        let doc: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(doc["diagnostics"].as_array().unwrap().is_empty());
+        assert!(err.is_empty());
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,273 @@
+//! Machine-readable rendering of diagnostics.
+//!
+//! The human-readable `plain` format stays in `main.rs` (it keeps the
+//! stdin/files path distinction). This module builds the aggregated `json` and
+//! `sarif` documents, which need a path per diagnostic and emit a single
+//! document for the whole run.
+
+use crate::diagnostic::{Diagnostic, Severity};
+use serde_json::{Value, json};
+use std::io::{self, Write};
+
+/// Output format selected via `--format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable `row:col: message` (optionally path-prefixed). Default.
+    Plain,
+    /// A single JSON document with a flat `diagnostics` array.
+    Json,
+    /// SARIF 2.1.0, for GitHub code scanning and editor integrations.
+    Sarif,
+}
+
+/// One file's diagnostics, as seen by the machine-readable formatters. For the
+/// stdin path the `path` is a placeholder such as `<stdin>`.
+pub struct FileDiagnostics<'a> {
+    pub path: &'a str,
+    pub diagnostics: &'a [Diagnostic],
+}
+
+/// Lowercase severity string shared by JSON (`severity`) and SARIF (`level`).
+/// SARIF levels are drawn from the same vocabulary (`warning`, `error`).
+const fn severity_str(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+    }
+}
+
+/// Serialize `value` as pretty JSON followed by a trailing newline.
+fn write_json_value<W: Write>(out: &mut W, value: &Value) -> io::Result<()> {
+    serde_json::to_writer_pretty(&mut *out, value).map_err(io::Error::other)?;
+    writeln!(out)
+}
+
+/// Write all diagnostics as a single JSON document with a flat `diagnostics` array.
+///
+/// Each entry carries its file path, rule id, severity and 1-based coordinates
+/// so CI tooling can consume them without parsing the plain text.
+pub fn write_json<W: Write>(out: &mut W, files: &[FileDiagnostics]) -> io::Result<()> {
+    let diagnostics: Vec<Value> = files
+        .iter()
+        .flat_map(|file| {
+            file.diagnostics.iter().map(move |d| {
+                json!({
+                    "path": file.path,
+                    "rule_id": d.rule_id(),
+                    "severity": severity_str(d.severity()),
+                    "row": d.row(),
+                    "col": d.col(),
+                    "message": d.message(),
+                })
+            })
+        })
+        .collect();
+
+    write_json_value(out, &json!({ "diagnostics": diagnostics }))
+}
+
+/// Write all diagnostics as a SARIF 2.1.0 document. `version` is the tool
+/// version reported in `tool.driver.version`.
+pub fn write_sarif<W: Write>(
+    out: &mut W,
+    files: &[FileDiagnostics],
+    version: &str,
+) -> io::Result<()> {
+    let results: Vec<Value> = files
+        .iter()
+        .flat_map(|file| {
+            file.diagnostics.iter().map(move |d| {
+                json!({
+                    "ruleId": d.rule_id(),
+                    "level": severity_str(d.severity()),
+                    "message": { "text": d.message() },
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": { "uri": file.path },
+                            "region": { "startLine": d.row(), "startColumn": d.col() },
+                        }
+                    }],
+                })
+            })
+        })
+        .collect();
+
+    // Advertise the distinct rules that produced results, in a stable order.
+    let mut rule_ids: Vec<&str> = files
+        .iter()
+        .flat_map(|file| file.diagnostics.iter().map(Diagnostic::rule_id))
+        .collect();
+    rule_ids.sort_unstable();
+    rule_ids.dedup();
+    let rules: Vec<Value> = rule_ids.iter().map(|id| json!({ "id": id })).collect();
+
+    let doc = json!({
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "bqvalid",
+                    "informationUri": "https://github.com/hirosassa/bqvalid",
+                    "version": version,
+                    "rules": rules,
+                }
+            },
+            "results": results,
+        }],
+    });
+
+    write_json_value(out, &doc)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "test code")]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<Diagnostic> {
+        vec![
+            Diagnostic::new(
+                "use_current_date",
+                Severity::Warning,
+                2,
+                3,
+                "Don't use CURRENT_DATE".to_string(),
+            ),
+            Diagnostic::new(
+                "invalid_group_by",
+                Severity::Error,
+                5,
+                1,
+                "Not in GROUP BY".to_string(),
+            ),
+        ]
+    }
+
+    fn render_json(files: &[FileDiagnostics]) -> Value {
+        let mut buf = Vec::new();
+        write_json(&mut buf, files).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    fn render_sarif(files: &[FileDiagnostics], version: &str) -> Value {
+        let mut buf = Vec::new();
+        write_sarif(&mut buf, files, version).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    #[test]
+    fn json_emits_one_entry_per_diagnostic_with_all_fields() {
+        let diags = sample();
+        let files = vec![FileDiagnostics {
+            path: "a.sql",
+            diagnostics: &diags,
+        }];
+        let doc = render_json(&files);
+
+        let entries = doc["diagnostics"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+
+        let first = &entries[0];
+        assert_eq!(first["path"], "a.sql");
+        assert_eq!(first["rule_id"], "use_current_date");
+        assert_eq!(first["severity"], "warning");
+        assert_eq!(first["row"], 2);
+        assert_eq!(first["col"], 3);
+        assert_eq!(first["message"], "Don't use CURRENT_DATE");
+
+        // Error severity is rendered as "error".
+        assert_eq!(entries[1]["severity"], "error");
+    }
+
+    #[test]
+    fn json_aggregates_diagnostics_across_files() {
+        let a = sample();
+        let b = sample();
+        let files = vec![
+            FileDiagnostics {
+                path: "a.sql",
+                diagnostics: &a,
+            },
+            FileDiagnostics {
+                path: "b.sql",
+                diagnostics: &b,
+            },
+        ];
+        let doc = render_json(&files);
+        assert_eq!(doc["diagnostics"].as_array().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn json_with_no_diagnostics_is_an_empty_array() {
+        let files: Vec<FileDiagnostics> = Vec::new();
+        let doc = render_json(&files);
+        assert!(doc["diagnostics"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sarif_has_the_2_1_0_envelope_and_tool_driver() {
+        let diags = sample();
+        let files = vec![FileDiagnostics {
+            path: "a.sql",
+            diagnostics: &diags,
+        }];
+        let doc = render_sarif(&files, "1.2.3");
+
+        assert_eq!(doc["version"], "2.1.0");
+        let driver = &doc["runs"][0]["tool"]["driver"];
+        assert_eq!(driver["name"], "bqvalid");
+        assert_eq!(driver["version"], "1.2.3");
+    }
+
+    #[test]
+    fn sarif_maps_each_diagnostic_to_a_result_with_location_and_level() {
+        let diags = sample();
+        let files = vec![FileDiagnostics {
+            path: "a.sql",
+            diagnostics: &diags,
+        }];
+        let doc = render_sarif(&files, "1.2.3");
+
+        let results = doc["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+
+        let first = &results[0];
+        assert_eq!(first["ruleId"], "use_current_date");
+        assert_eq!(first["level"], "warning");
+        assert_eq!(first["message"]["text"], "Don't use CURRENT_DATE");
+
+        let region = &first["locations"][0]["physicalLocation"]["region"];
+        assert_eq!(region["startLine"], 2);
+        assert_eq!(region["startColumn"], 3);
+        let uri = &first["locations"][0]["physicalLocation"]["artifactLocation"]["uri"];
+        assert_eq!(uri, "a.sql");
+
+        // Error severity maps to the SARIF "error" level.
+        assert_eq!(results[1]["level"], "error");
+    }
+
+    #[test]
+    fn sarif_lists_distinct_rules_sorted_and_deduped() {
+        // Two files each trip both rules; the driver should list each rule once.
+        let a = sample();
+        let b = sample();
+        let files = vec![
+            FileDiagnostics {
+                path: "a.sql",
+                diagnostics: &a,
+            },
+            FileDiagnostics {
+                path: "b.sql",
+                diagnostics: &b,
+            },
+        ];
+        let doc = render_sarif(&files, "1.2.3");
+
+        let rules = doc["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        let ids: Vec<&str> = rules.iter().map(|r| r["id"].as_str().unwrap()).collect();
+        assert_eq!(ids, vec!["invalid_group_by", "use_current_date"]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds machine-readable output formats so `bqvalid` can integrate with CI and editors. Previously it only emitted human-readable `row:col: message` text.

- Add `--format <plain|json|sarif>` (default `plain`) via clap `ValueEnum`
- New `src/output.rs`: JSON and SARIF 2.1.0 formatters, hand-built with `serde_json`
- `plain` output is unchanged (stdin = no path prefix, files = path-prefixed)
- `json`/`sarif` aggregate all results into a single stdout document; read/parse
  errors still go to stderr, so output stays pipe-clean

## Details

- stdin path uses `<stdin>` as the location
- Severity maps `Warning` → `warning`, `Error` → `error`
- SARIF `tool.driver.rules` lists observed rule IDs, sorted and deduped