### PR TITLE
docs: update rule-authoring guide for Rule trait registry and severity

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -6,8 +6,12 @@ If you want to add new linting rules, use the following steps:
 
 1. Check the [issues page](https://github.com/hirosassa/bqvalid/issues) on GitHub to see if the task you want to complete is listed there.
 1. Create an issue branch for your local work.
-1. Add your code in `src/rules/` and implement `pub fn check(tree &Tree, sql: &str)` function in it.
-1. Call your new rules from `analyse_sql` function in `src/main.rs`.
+1. Add your code in `src/rules/` and implement the `Rule` trait (defined in `src/rules/rule.rs`) for it:
+   - `id` returns a stable, unique identifier for the rule (used in machine-readable output).
+   - Node-driven rules override `check_node`, which is called once per node during the shared pre-order traversal.
+   - Rules that need cross-node analysis override `check_tree` and walk the tree themselves.
+   - Each `Diagnostic` you emit carries a `Severity` (`Error` for queries BigQuery would reject, `Warning` for performance/maintainability problems).
+1. Register your rule by adding one entry to `all_rules()` in `src/rules/rule.rs`. This is the single place rules are wired in; you do not need to touch the analysis loop or `src/main.rs`.
 1. Write unit tests for your code and make sure everything is still working.
 1. Submit a pull request to the main branch of this repository. For complex implementations, add performance benchmarks in `benches/` and include the results in the pull request description.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,6 +2,19 @@
 
 The list of the linting rules are as follows.
 
+Each rule has a severity: `Error` marks a query that BigQuery would reject at
+runtime, and `Warning` marks a performance or maintainability problem that still
+runs. The severity is carried in the machine-readable output (see `--format` in
+the [README](https://github.com/hirosassa/bqvalid/blob/main/README.md#output-formats)).
+
+| Rule | Severity |
+| --- | --- |
+| Comparing `_TABLE_SUFFIX` with subquery | Warning |
+| Using CURRENT_DATE | Warning |
+| Contains unused columns in CTE | Warning |
+| Unnecessary ORDER BY in CTE or subquery | Warning |
+| Invalid GROUP BY usage | Error |
+
 ## Comparing `_TABLE_SUFFIX` with subquery
 
 Comparing `_TABLE_SUFFIX` pseudo column with dynamic expression like subquery will cause full scan on wildcard tables.


### PR DESCRIPTION
## Summary

Documentation drifted out of sync with the rule-architecture, severity, and output changes landed in #59–#67. This PR updates the docs to match the current code.

## Changes

- **`docs/contribute.md`**: Rewrote the "add a new rule" steps from the old `pub fn check(tree, sql)` + `analyse_sql` wiring to the current model — implement the `Rule` trait (`id` / `check_node` / `check_tree`, with a `Severity` per `Diagnostic`) and register it in `all_rules()` (#61).
- **`docs/rules.md`**: Added a severity overview and a per-rule `Error` / `Warning` table (#63).

## Notes

- No code changes; docs only.