### PR TITLE
feat(rules): add --ignore flag and bqvalid.toml config to suppress rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "tree-sitter",
  "tree-sitter-sql-bigquery",
  "walkdir",
@@ -776,7 +777,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1001,6 +1002,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1086,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,12 +1117,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -1104,6 +1149,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tree-sitter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap-verbosity-flag = "3.0.4"
 rayon = "1.12.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,46 @@ bqvalid --format sarif sql/   # SARIF 2.1.0, e.g. for GitHub code scanning
 Lint diagnostics go to stdout; the tool's own errors (unreadable files, parse
 failures) go to stderr, so either format can be piped cleanly.
 
+### Ignoring rules
+
+Every rule is enabled by default. You can suppress individual rules by their
+stable rule ID (listed on the [rules page](https://github.com/hirosassa/bqvalid/blob/main/docs/rules.md))
+either on the command line or via a config file.
+
+On the command line, pass `--ignore` with a rule ID. To ignore more than one
+rule, give a comma-separated list or repeat the flag:
+
+```shell
+# ignore a single rule
+bqvalid --ignore use_current_date sql/
+
+# ignore multiple rules, comma-separated
+bqvalid --ignore use_current_date,unnecessary_order_by sql/
+
+# equivalently, by repeating the flag
+bqvalid --ignore use_current_date --ignore unnecessary_order_by sql/
+```
+
+Or put the ignore list in a `bqvalid.toml` file:
+
+```toml
+# bqvalid.toml
+ignore = ["use_current_date", "unnecessary_order_by"]
+```
+
+`bqvalid` looks for `bqvalid.toml` in the current directory and walks up to the
+git repository root (the directory containing `.git`), using the nearest one it
+finds; outside a git repository only the current directory is checked. Point at
+a specific file with `--config`:
+
+```shell
+bqvalid --config path/to/bqvalid.toml sql/
+```
+
+When `--ignore` is given on the command line it replaces (does not merge with)
+the `ignore` list from the config file. An unknown rule ID is reported as a
+warning on stderr rather than silently ignored.
+
 ## Linting Rules
 
 See the [rules page](https://github.com/hirosassa/bqvalid/blob/main/docs/rules.md)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -7,13 +7,17 @@ runtime, and `Warning` marks a performance or maintainability problem that still
 runs. The severity is carried in the machine-readable output (see `--format` in
 the [README](https://github.com/hirosassa/bqvalid/blob/main/README.md#output-formats)).
 
-| Rule | Severity |
-| --- | --- |
-| Comparing `_TABLE_SUFFIX` with subquery | Warning |
-| Using CURRENT_DATE | Warning |
-| Contains unused columns in CTE | Warning |
-| Unnecessary ORDER BY in CTE or subquery | Warning |
-| Invalid GROUP BY usage | Error |
+The `Rule ID` is the stable identifier used to disable a rule via `--ignore` or
+the config file (see
+[Ignoring rules](https://github.com/hirosassa/bqvalid/blob/main/README.md#ignoring-rules)).
+
+| Rule | Rule ID | Severity |
+| --- | --- | --- |
+| Comparing `_TABLE_SUFFIX` with subquery | `compare_table_suffix_with_subquery` | Warning |
+| Using CURRENT_DATE | `use_current_date` | Warning |
+| Contains unused columns in CTE | `unused_column_in_cte` | Warning |
+| Unnecessary ORDER BY in CTE or subquery | `unnecessary_order_by` | Warning |
+| Invalid GROUP BY usage | `invalid_group_by` | Error |
 
 ## Comparing `_TABLE_SUFFIX` with subquery
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,6 +170,18 @@ mod tests {
     }
 
     #[test]
+    fn read_error_displays_a_helpful_message() {
+        // A missing --config file surfaces to the user as this message, so the
+        // Read variant's Display is part of the contract.
+        let dir = tempdir().unwrap();
+        let err = Config::load(&dir.path().join("missing.toml")).unwrap_err();
+        assert!(
+            err.to_string().contains("cannot read config file"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn load_malformed_toml_is_a_parse_error() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("bad.toml");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,310 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Config file looked up in the current directory when `--config` is not given.
+pub const DEFAULT_CONFIG_FILE: &str = "bqvalid.toml";
+
+/// User configuration deserialized from a TOML file.
+///
+/// Unknown keys are rejected so typos surface as errors rather than being
+/// silently ignored.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Rule IDs whose diagnostics are suppressed.
+    #[serde(default)]
+    pub ignore: Vec<String>,
+}
+
+/// Failure while loading a config file: either the file could not be read or
+/// its contents could not be parsed as the expected TOML.
+#[derive(Debug)]
+pub enum ConfigError {
+    Read(std::io::Error),
+    Parse(toml::de::Error),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read(e) => write!(f, "cannot read config file: {e}"),
+            Self::Parse(e) => write!(f, "cannot parse config file: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read(e) => Some(e),
+            Self::Parse(e) => Some(e),
+        }
+    }
+}
+
+impl Config {
+    /// Parse a config from TOML text.
+    pub fn from_toml(text: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(text)
+    }
+
+    /// Read and parse the config file at `path`.
+    pub fn load(path: &Path) -> Result<Self, ConfigError> {
+        let text = std::fs::read_to_string(path).map_err(ConfigError::Read)?;
+        Self::from_toml(&text).map_err(ConfigError::Parse)
+    }
+}
+
+/// Resolve which config file to load.
+///
+/// The explicit `--config` path always wins; otherwise the default file is
+/// searched for in `start_dir` and each of its ancestors, using the nearest one
+/// found. The search never goes above the git repository root (the directory
+/// containing `.git`); outside any git repository only `start_dir` itself is
+/// searched. Returns `None` when no config exists within that range.
+pub fn discover_config(explicit: Option<PathBuf>, start_dir: &Path) -> Option<PathBuf> {
+    if explicit.is_some() {
+        return explicit;
+    }
+    // The search ceiling is the git repository root if there is one; otherwise
+    // `start_dir` itself, so we never walk up out of an untracked directory.
+    let ceiling = start_dir
+        .ancestors()
+        .find(|dir| dir.join(".git").exists())
+        .unwrap_or(start_dir);
+    for dir in start_dir.ancestors() {
+        let candidate = dir.join(DEFAULT_CONFIG_FILE);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if dir == ceiling {
+            break;
+        }
+    }
+    None
+}
+
+/// Resolve the effective ignore list. A non-empty CLI `--ignore` overrides the
+/// config's `ignore` wholesale (replacement, not merge); otherwise the config
+/// value is used.
+pub fn effective_ignore(cli_ignore: Vec<String>, config_ignore: Vec<String>) -> Vec<String> {
+    if cli_ignore.is_empty() {
+        config_ignore
+    } else {
+        cli_ignore
+    }
+}
+
+/// Return the ignore entries that match no known rule id, preserving input
+/// order, so the caller can warn about likely typos instead of silently
+/// ignoring them.
+pub fn unknown_ignore_ids(ignore: &[String], known: &HashSet<&str>) -> Vec<String> {
+    ignore
+        .iter()
+        .filter(|id| !known.contains(id.as_str()))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "test code"
+)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn from_toml_parses_ignore_list() {
+        let cfg = Config::from_toml("ignore = [\"use_current_date\", \"invalid_group_by\"]")
+            .expect("valid toml");
+        assert_eq!(
+            cfg.ignore,
+            vec![
+                "use_current_date".to_string(),
+                "invalid_group_by".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn from_toml_defaults_ignore_to_empty_when_absent() {
+        let cfg = Config::from_toml("").expect("empty is valid");
+        assert!(cfg.ignore.is_empty());
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn from_toml_rejects_unknown_keys() {
+        // A typo'd key must be an error, not a silently ignored no-op.
+        let err = Config::from_toml("ingore = [\"x\"]");
+        assert!(err.is_err(), "unknown key should be rejected");
+    }
+
+    #[test]
+    fn load_reads_and_parses_a_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bqvalid.toml");
+        fs::write(&path, "ignore = [\"unnecessary_order_by\"]").unwrap();
+
+        let cfg = Config::load(&path).expect("loads");
+        assert_eq!(cfg.ignore, vec!["unnecessary_order_by".to_string()]);
+    }
+
+    #[test]
+    fn load_missing_file_is_a_read_error() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope.toml");
+        match Config::load(&missing) {
+            Err(ConfigError::Read(_)) => {}
+            other => panic!("expected a read error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_malformed_toml_is_a_parse_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        fs::write(&path, "ignore = not-a-list").unwrap();
+        match Config::load(&path) {
+            Err(ConfigError::Parse(_)) => {}
+            other => panic!("expected a parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn discover_prefers_explicit_path() {
+        let dir = tempdir().unwrap();
+        let explicit = PathBuf::from("/somewhere/custom.toml");
+        assert_eq!(
+            discover_config(Some(explicit.clone()), dir.path()),
+            Some(explicit)
+        );
+    }
+
+    #[test]
+    fn discover_finds_default_file_in_cwd() {
+        let dir = tempdir().unwrap();
+        let default = dir.path().join(DEFAULT_CONFIG_FILE);
+        fs::write(&default, "").unwrap();
+        assert_eq!(discover_config(None, dir.path()), Some(default));
+    }
+
+    #[test]
+    fn discover_returns_none_when_no_default_exists() {
+        let dir = tempdir().unwrap();
+        assert_eq!(discover_config(None, dir.path()), None);
+    }
+
+    #[test]
+    fn discover_walks_up_to_the_git_root() {
+        // The config lives at the git repository root; discovery from a nested
+        // working directory must find it by walking upwards.
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        let root_config = dir.path().join(DEFAULT_CONFIG_FILE);
+        fs::write(&root_config, "").unwrap();
+        let nested = dir.path().join("sub").join("dir");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(discover_config(None, &nested), Some(root_config));
+    }
+
+    #[test]
+    fn discover_does_not_search_above_the_git_root() {
+        // A config above the git root must not be picked up: discovery stops at
+        // the repository boundary.
+        let base = tempdir().unwrap();
+        fs::write(base.path().join(DEFAULT_CONFIG_FILE), "").unwrap();
+        let repo = base.path().join("repo");
+        let nested = repo.join("sub");
+        fs::create_dir_all(&nested).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
+
+        assert_eq!(discover_config(None, &nested), None);
+    }
+
+    #[test]
+    fn discover_finds_config_at_the_git_root() {
+        let base = tempdir().unwrap();
+        let repo = base.path().join("repo");
+        let nested = repo.join("sub");
+        fs::create_dir_all(&nested).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
+        let repo_config = repo.join(DEFAULT_CONFIG_FILE);
+        fs::write(&repo_config, "").unwrap();
+
+        assert_eq!(discover_config(None, &nested), Some(repo_config));
+    }
+
+    #[test]
+    fn discover_outside_a_git_repo_does_not_walk_up() {
+        // With no git root to anchor to, only the start directory is searched.
+        let base = tempdir().unwrap();
+        fs::write(base.path().join(DEFAULT_CONFIG_FILE), "").unwrap();
+        let nested = base.path().join("sub");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(discover_config(None, &nested), None);
+    }
+
+    #[test]
+    fn discover_prefers_the_nearest_ancestor_config() {
+        // With a config at both the root and a nested directory, the nearest one
+        // (closest to the start directory) wins.
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(DEFAULT_CONFIG_FILE), "").unwrap();
+        let nested = dir.path().join("sub");
+        fs::create_dir_all(&nested).unwrap();
+        let nested_config = nested.join(DEFAULT_CONFIG_FILE);
+        fs::write(&nested_config, "").unwrap();
+
+        assert_eq!(discover_config(None, &nested), Some(nested_config));
+    }
+
+    #[test]
+    fn effective_ignore_prefers_cli_when_present() {
+        let cli = vec!["a".to_string()];
+        let config = vec!["b".to_string(), "c".to_string()];
+        assert_eq!(
+            effective_ignore(cli, config),
+            vec!["a".to_string()],
+            "CLI overrides config wholesale"
+        );
+    }
+
+    #[test]
+    fn effective_ignore_falls_back_to_config_when_cli_empty() {
+        let config = vec!["b".to_string()];
+        assert_eq!(
+            effective_ignore(Vec::new(), config.clone()),
+            config,
+            "config is used when CLI is empty"
+        );
+    }
+
+    #[test]
+    fn unknown_ignore_ids_flags_only_unrecognised_entries() {
+        let known: HashSet<&str> = ["invalid_group_by", "use_current_date"]
+            .into_iter()
+            .collect();
+        let ignore = vec![
+            "use_current_date".to_string(),
+            "typo_rule".to_string(),
+            "another_typo".to_string(),
+        ];
+        assert_eq!(
+            unknown_ignore_ids(&ignore, &known),
+            vec!["typo_rule".to_string(), "another_typo".to_string()],
+            "known ids are kept, unknown ones are reported in order"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod diagnostic;
 pub mod output;
 pub mod rules;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
+use bqvalid::config::{self, Config};
 use bqvalid::diagnostic::Diagnostic;
 use bqvalid::output::{self, FileResult, OutputFormat};
-use bqvalid::rules::run_rules;
+use bqvalid::rules::{known_rule_ids, run_rules_ignoring};
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
 use log::debug;
 use rayon::prelude::*;
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, Read, Stdin};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use tree_sitter::Parser as TsParser;
 use tree_sitter_sql_bigquery::language;
@@ -34,6 +36,17 @@ struct Args {
     #[clap(long, value_enum, default_value_t = OutputFormat::Plain)]
     format: OutputFormat,
 
+    /// Rule id to ignore (suppress its diagnostics). Accepts a comma-separated
+    /// list and is repeatable. When given, overrides the `ignore` list from the
+    /// config file.
+    #[clap(long, value_name = "RULE_ID", value_delimiter = ',')]
+    ignore: Vec<String>,
+
+    /// Path to a TOML config file. Defaults to `bqvalid.toml` in the current
+    /// directory when present.
+    #[clap(long, value_name = "PATH")]
+    config: Option<PathBuf>,
+
     #[clap(flatten)]
     verbose: Verbosity,
 }
@@ -46,15 +59,23 @@ fn main() -> ExitCode {
         .init();
     debug!("verbose mode");
 
+    let ignore = match resolve_ignore(args.config, args.ignore) {
+        Ok(ignore) => ignore,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
+
     // Both inputs converge on `Vec<FileResult>`; `show_paths` only distinguishes
     // the two in the plain format (files prefix the path, stdin does not).
     let (results, show_paths) = if args.files.is_empty() {
-        match analyse_stdin(&stdin) {
+        match analyse_stdin(&stdin, &ignore) {
             Some(results) => (results, false),
             None => return ExitCode::FAILURE,
         }
     } else {
-        (analyse_paths(collect_targets(args.files)), true)
+        (analyse_paths(collect_targets(args.files), &ignore), true)
     };
 
     let mut out = io::stdout().lock();
@@ -79,7 +100,7 @@ fn main() -> ExitCode {
 /// Read SQL from stdin and analyse it as a single `<stdin>` result. Returns
 /// `None` (after logging to stderr) when the input cannot be read or the
 /// grammar fails to load, so the caller can exit with a failure code.
-fn analyse_stdin(stdin: &Stdin) -> Option<Vec<FileResult>> {
+fn analyse_stdin(stdin: &Stdin, ignore: &HashSet<String>) -> Option<Vec<FileResult>> {
     let mut sql = String::new();
     let read_result = stdin.lock().read_to_string(&mut sql);
     if let Err(e) = read_result {
@@ -89,7 +110,7 @@ fn analyse_stdin(stdin: &Stdin) -> Option<Vec<FileResult>> {
     let mut parser = new_parser()?;
     Some(vec![FileResult {
         path: PathBuf::from("<stdin>"),
-        diagnostics: analyse_sql(&mut parser, &sql),
+        diagnostics: analyse_sql(&mut parser, &sql, ignore),
         read_error: None,
     }])
 }
@@ -141,14 +162,14 @@ fn new_parser() -> Option<TsParser> {
 /// (via `map_init`) and reuses it across the files it handles, so the grammar
 /// is loaded per thread rather than per file. Results are sorted by path so the
 /// output is stable regardless of scheduling.
-fn analyse_paths(paths: Vec<PathBuf>) -> Vec<FileResult> {
+fn analyse_paths(paths: Vec<PathBuf>, ignore: &HashSet<String>) -> Vec<FileResult> {
     let mut results: Vec<FileResult> = paths
         .par_iter()
         .map_init(new_parser, |parser, path| match fs::read_to_string(path) {
             Ok(sql) => {
                 let diagnostics = parser
                     .as_mut()
-                    .map_or_else(Vec::new, |parser| analyse_sql(parser, &sql));
+                    .map_or_else(Vec::new, |parser| analyse_sql(parser, &sql, ignore));
                 FileResult {
                     path: path.clone(),
                     diagnostics,
@@ -166,13 +187,46 @@ fn analyse_paths(paths: Vec<PathBuf>) -> Vec<FileResult> {
     results
 }
 
-fn analyse_sql(parser: &mut TsParser, sql: &str) -> Vec<Diagnostic> {
+fn analyse_sql(parser: &mut TsParser, sql: &str, ignore: &HashSet<String>) -> Vec<Diagnostic> {
     let Some(tree) = parser.parse(sql, None) else {
         eprintln!("Error parsing SQL input");
         return Vec::new();
     };
 
-    run_rules(&tree, sql)
+    run_rules_ignoring(&tree, sql, ignore)
+}
+
+/// Resolve the effective set of ignored rule ids from the config file and CLI.
+/// Discovers the config by walking up from the current directory to the git
+/// repository root, lets a non-empty CLI `--ignore` override it, and warns
+/// about ids that match no known rule. Returns an error string when the config
+/// cannot be loaded.
+fn resolve_ignore(
+    config_path: Option<PathBuf>,
+    cli_ignore: Vec<String>,
+) -> Result<HashSet<String>, String> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| format!("cannot determine current directory: {}", e))?;
+    resolve_ignore_in(&cwd, config_path, cli_ignore)
+}
+
+/// Core of [`resolve_ignore`], parameterized by the directory used to discover
+/// the default config file so it can be exercised without touching the process
+/// working directory.
+fn resolve_ignore_in(
+    cwd: &Path,
+    config_path: Option<PathBuf>,
+    cli_ignore: Vec<String>,
+) -> Result<HashSet<String>, String> {
+    let config = match config::discover_config(config_path, cwd) {
+        Some(path) => Config::load(&path).map_err(|e| e.to_string())?,
+        None => Config::default(),
+    };
+    let ignore = config::effective_ignore(cli_ignore, config.ignore);
+    for id in config::unknown_ignore_ids(&ignore, &known_rule_ids()) {
+        eprintln!("Warning: unknown rule id in ignore list: {}", id);
+    }
+    Ok(ignore.into_iter().collect())
 }
 
 #[cfg(test)]
@@ -193,7 +247,7 @@ mod tests {
     /// binary drives `analyse_sql`.
     fn analyse(sql: &str) -> Vec<Diagnostic> {
         let mut parser = new_parser().expect("grammar loads");
-        analyse_sql(&mut parser, sql)
+        analyse_sql(&mut parser, sql, &HashSet::new())
     }
 
     #[test]
@@ -239,7 +293,7 @@ where
 ";
         let tree = parser.parse(sql, None).unwrap();
 
-        let diagnostics = run_rules(&tree, sql);
+        let diagnostics = run_rules_ignoring(&tree, sql, &HashSet::new());
         assert!(diagnostics.len() > 1);
     }
 
@@ -260,8 +314,8 @@ where
         // grammar. Each parse must stay independent (no state leaking between
         // calls), so a clean query after a dirty one still yields nothing.
         let mut parser = new_parser().expect("grammar loads");
-        let dirty = analyse_sql(&mut parser, "SELECT CURRENT_DATE()");
-        let clean = analyse_sql(&mut parser, "SELECT id FROM users");
+        let dirty = analyse_sql(&mut parser, "SELECT CURRENT_DATE()", &HashSet::new());
+        let clean = analyse_sql(&mut parser, "SELECT id FROM users", &HashSet::new());
         assert!(!dirty.is_empty(), "dirty query should produce diagnostics");
         assert!(clean.is_empty(), "clean query should produce none");
     }
@@ -320,7 +374,7 @@ where
             dir.path().join("b.sql"),
         ];
 
-        let results = analyse_paths(paths);
+        let results = analyse_paths(paths, &HashSet::new());
 
         let ordered: Vec<PathBuf> = results.iter().map(|r| r.path.clone()).collect();
         let mut expected = ordered.clone();
@@ -340,11 +394,87 @@ where
         let dir = tempdir().unwrap();
         let missing = dir.path().join("does_not_exist.sql");
 
-        let results = analyse_paths(vec![missing.clone()]);
+        let results = analyse_paths(vec![missing.clone()], &HashSet::new());
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].path, missing);
         assert!(results[0].read_error.is_some());
         assert!(results[0].diagnostics.is_empty());
+    }
+
+    #[test]
+    fn resolve_ignore_reads_the_config_ignore_list() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("bqvalid.toml"),
+            "ignore = [\"use_current_date\"]",
+        )
+        .unwrap();
+
+        let ignore = resolve_ignore_in(dir.path(), None, Vec::new()).expect("loads config");
+        assert_eq!(
+            ignore,
+            std::iter::once("use_current_date".to_string()).collect()
+        );
+    }
+
+    #[test]
+    fn resolve_ignore_cli_overrides_config_file() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("bqvalid.toml"),
+            "ignore = [\"use_current_date\"]",
+        )
+        .unwrap();
+
+        let ignore = resolve_ignore_in(dir.path(), None, vec!["invalid_group_by".to_string()])
+            .expect("loads config");
+        assert_eq!(
+            ignore,
+            std::iter::once("invalid_group_by".to_string()).collect(),
+            "CLI --ignore replaces the config list"
+        );
+    }
+
+    #[test]
+    fn resolve_ignore_is_empty_without_config_or_cli() {
+        let dir = tempdir().unwrap();
+        let ignore = resolve_ignore_in(dir.path(), None, Vec::new()).expect("no config is fine");
+        assert!(ignore.is_empty());
+    }
+
+    #[test]
+    fn ignore_flag_accepts_comma_separated_rules() {
+        let args = Args::try_parse_from([
+            "bqvalid",
+            "--ignore",
+            "use_current_date,unnecessary_order_by",
+            "x.sql",
+        ])
+        .expect("parses");
+        assert_eq!(
+            args.ignore,
+            vec![
+                "use_current_date".to_string(),
+                "unnecessary_order_by".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn ignore_flag_still_accepts_repeated_flags() {
+        let args = Args::try_parse_from(["bqvalid", "--ignore", "a", "--ignore", "b", "x.sql"])
+            .expect("parses");
+        assert_eq!(args.ignore, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn resolve_ignore_reports_a_broken_config() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("custom.toml");
+        fs::write(&path, "ignore = not-a-list").unwrap();
+
+        let err = resolve_ignore_in(dir.path(), Some(path), Vec::new());
+        assert!(err.is_err(), "a malformed config must be a hard error");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,4 +477,34 @@ where
         let err = resolve_ignore_in(dir.path(), Some(path), Vec::new());
         assert!(err.is_err(), "a malformed config must be a hard error");
     }
+
+    #[test]
+    fn resolve_ignore_reports_a_missing_explicit_config() {
+        // An explicit --config that cannot be read must fail loudly rather than
+        // being silently treated as "no config".
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does_not_exist.toml");
+
+        let err = resolve_ignore_in(dir.path(), Some(missing), Vec::new());
+        assert!(err.is_err(), "a missing explicit config must be an error");
+    }
+
+    #[test]
+    fn resolve_ignore_keeps_unknown_ids_without_failing() {
+        // An unknown rule id is warned about on stderr but must not be dropped
+        // or turned into an error: downstream it simply matches no rule.
+        let dir = tempdir().unwrap();
+
+        let ignore = resolve_ignore_in(
+            dir.path(),
+            None,
+            vec!["use_current_date".to_string(), "not_a_rule".to_string()],
+        )
+        .expect("unknown ids are not an error");
+
+        let expected: HashSet<String> = ["use_current_date".to_string(), "not_a_rule".to_string()]
+            .into_iter()
+            .collect();
+        assert_eq!(ignore, expected, "unknown ids are retained, not dropped");
+    }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -6,4 +6,4 @@ pub mod unnecessary_order_by;
 pub mod unused_column_in_cte;
 pub mod use_current_date;
 
-pub use rule::{Rule, all_rules, run_rules};
+pub use rule::{Rule, all_rules, known_rule_ids, run_rules, run_rules_ignoring};

--- a/src/rules/rule.rs
+++ b/src/rules/rule.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use tree_sitter::{Node, Tree};
 use tree_sitter_traversal::{Order, traverse};
 
@@ -56,14 +58,29 @@ pub fn all_rules() -> Vec<Box<dyn Rule>> {
     ]
 }
 
-/// Run all registered rules over `tree` in a single pre-order traversal.
+/// The id of every registered rule. Callers use this to validate user-supplied
+/// ignore lists so unknown ids can be reported rather than silently dropped.
+pub fn known_rule_ids() -> HashSet<&'static str> {
+    all_rules().iter().map(|r| r.id()).collect()
+}
+
+/// Run every registered rule over `tree`, see [`run_rules_ignoring`].
+pub fn run_rules(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
+    run_rules_ignoring(tree, sql, &HashSet::new())
+}
+
+/// Run the registered rules over `tree` in a single pre-order traversal,
+/// skipping any rule whose id is in `ignore`.
 ///
 /// Node-driven rules each inspect every node during the one shared pass, rather
 /// than each rule walking the whole tree on its own. Tree-driven rules run
 /// afterwards. Diagnostics come out in traversal order for the node-driven
 /// rules, followed by the tree-driven ones.
-pub fn run_rules(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    let rules = all_rules();
+pub fn run_rules_ignoring(tree: &Tree, sql: &str, ignore: &HashSet<String>) -> Vec<Diagnostic> {
+    let rules: Vec<Box<dyn Rule>> = all_rules()
+        .into_iter()
+        .filter(|rule| !ignore.contains(rule.id()))
+        .collect();
     let mut diagnostics = Vec::new();
 
     for node in traverse(tree.walk(), Order::Pre) {
@@ -154,5 +171,67 @@ mod tests {
         let sql = "SELECT id, name FROM users";
         let tree = parse_sql(sql);
         assert!(run_rules(&tree, sql).is_empty());
+    }
+
+    #[test]
+    fn known_rule_ids_matches_the_registry() {
+        let ids = known_rule_ids();
+        assert_eq!(ids.len(), all_rules().len());
+        assert!(ids.contains("use_current_date"));
+        assert!(ids.contains("compare_table_suffix_with_subquery"));
+    }
+
+    #[test]
+    fn run_rules_ignoring_skips_the_named_rule() {
+        // This query trips use_current_date and compare_table_suffix_with_subquery.
+        // Ignoring the former must drop only its diagnostic, leaving the other.
+        let sql = "SELECT CURRENT_DATE() AS d \
+                   FROM t \
+                   WHERE _TABLE_SUFFIX = (SELECT MAX(suffix) FROM u)";
+        let tree = parse_sql(sql);
+        let ignore: HashSet<String> = std::iter::once("use_current_date".to_string()).collect();
+
+        let diagnostics = run_rules_ignoring(&tree, sql, &ignore);
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.message().contains("CURRENT_DATE")),
+            "ignored rule must not fire"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message().contains("Full scan")),
+            "other rules must still fire"
+        );
+    }
+
+    #[test]
+    fn run_rules_ignoring_with_empty_set_matches_run_rules() {
+        let sql = "SELECT CURRENT_DATE() AS d FROM t";
+        let tree = parse_sql(sql);
+
+        let baseline: Vec<String> = run_rules(&tree, sql)
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let ignoring: Vec<String> = run_rules_ignoring(&tree, sql, &HashSet::new())
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        assert_eq!(baseline, ignoring);
+    }
+
+    #[test]
+    fn run_rules_ignoring_every_rule_yields_nothing() {
+        let sql = "SELECT CURRENT_DATE() AS d \
+                   FROM t \
+                   WHERE _TABLE_SUFFIX = (SELECT MAX(suffix) FROM u)";
+        let tree = parse_sql(sql);
+        let ignore: HashSet<String> = known_rule_ids().iter().map(|s| s.to_string()).collect();
+
+        assert!(run_rules_ignoring(&tree, sql, &ignore).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds a way to enable/disable individual lint rules, via both a TOML config file and command-line flags. All rules stay enabled by default; listed rules are suppressed (blacklist).

## Usage

Command line (comma-separated or repeated):

```shell
bqvalid --ignore use_current_date,unnecessary_order_by sql/
bqvalid --ignore use_current_date --ignore unnecessary_order_by sql/
```

Config file (bqvalid.toml):

```toml
ignore = ["use_current_date", "unnecessary_order_by"]
```

Point at a specific file with --config path/to/bqvalid.toml.

## Behavior

- Discovery: bqvalid.toml is looked up from the current directory up to the git repository root (the directory containing .git); outside a git repo only the current directory is checked. --config overrides discovery.
- Precedence: a non-empty CLI --ignore replaces (does not merge with) the config's ignore list.
- Validation: unknown rule IDs in the ignore list are reported as warnings on stderr rather than silently dropped; unknown TOML keys are hard errors.

## Implementation

- New src/config.rs: Config (serde/TOML), config discovery, precedence, and unknown-id detection.
- rules::run_rules_ignoring filters rules by ID in the shared traversal; run_rules is now a thin wrapper. Added known_rule_ids().
- main.rs: new --ignore / --config flags, ignore set resolved before analysis and threaded through.

## Docs

- README: new "Ignoring rules" section.
- docs/rules.md: added a Rule ID column.