### PR TITLE
refactor(parser): decouple rules from tree-sitter via a neutral AST

### DIFF
--- a/benches/memory_profile.rs
+++ b/benches/memory_profile.rs
@@ -13,12 +13,14 @@ use std::fs;
 use tree_sitter::Parser as TsParser;
 use tree_sitter_sql_bigquery::language;
 
+use bqvalid::ast::Ast;
 use bqvalid::rules::unused_column_in_cte;
 
-fn parse_sql(sql: &str) -> tree_sitter::Tree {
+fn parse_sql(sql: &str) -> Ast {
     let mut parser = TsParser::new();
     parser.set_language(&language()).unwrap();
-    parser.parse(sql, None).unwrap()
+    let tree = parser.parse(sql, None).unwrap();
+    Ast::from_tree_sitter(&tree)
 }
 
 fn run_check(name: &str, path: &str) {
@@ -26,8 +28,8 @@ fn run_check(name: &str, path: &str) {
 
     let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
 
-    let tree = parse_sql(&sql);
-    let diagnostics = unused_column_in_cte::check(&tree, &sql);
+    let ast = parse_sql(&sql);
+    let diagnostics = unused_column_in_cte::check(&ast, &sql);
 
     if diagnostics.is_empty() {
         println!("No unused columns found");

--- a/benches/unused_column_in_cte.rs
+++ b/benches/unused_column_in_cte.rs
@@ -13,12 +13,14 @@ use tree_sitter::Parser as TsParser;
 use tree_sitter_sql_bigquery::language;
 
 // Import the rule check function
+use bqvalid::ast::Ast;
 use bqvalid::rules::unused_column_in_cte;
 
-fn parse_sql(sql: &str) -> tree_sitter::Tree {
+fn parse_sql(sql: &str) -> Ast {
     let mut parser = TsParser::new();
     parser.set_language(&language()).unwrap();
-    parser.parse(sql, None).unwrap()
+    let tree = parser.parse(sql, None).unwrap();
+    Ast::from_tree_sitter(&tree)
 }
 
 fn bench_unused_column_check(c: &mut Criterion) {
@@ -32,14 +34,14 @@ fn bench_unused_column_check(c: &mut Criterion) {
 
     for (name, path) in test_cases {
         let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
-        let tree = parse_sql(&sql);
+        let ast = parse_sql(&sql);
 
         group.bench_with_input(
             BenchmarkId::new("check", name),
-            &(&tree, &sql),
-            |b, (tree, sql)| {
+            &(&ast, &sql),
+            |b, (ast, sql)| {
                 b.iter(|| {
-                    let result = unused_column_in_cte::check(black_box(tree), black_box(sql));
+                    let result = unused_column_in_cte::check(black_box(ast), black_box(sql));
                     black_box(result);
                 });
             },
@@ -63,8 +65,8 @@ fn bench_parse_and_check(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("full", name), &sql, |b, sql| {
             b.iter(|| {
-                let tree = parse_sql(black_box(sql));
-                let result = unused_column_in_cte::check(black_box(&tree), black_box(sql));
+                let ast = parse_sql(black_box(sql));
+                let result = unused_column_in_cte::check(black_box(&ast), black_box(sql));
                 black_box(result);
             });
         });

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -178,13 +178,13 @@ impl<'a> NodeRef<'a> {
     /// Start byte offset in the source.
     #[must_use]
     pub fn start_byte(&self) -> usize {
-        self.byte_range().start
+        self.data().map_or(0, |d| d.byte_range.start)
     }
 
     /// End byte offset in the source.
     #[must_use]
     pub fn end_byte(&self) -> usize {
-        self.byte_range().end
+        self.data().map_or(0, |d| d.byte_range.end)
     }
 
     /// The node's 0-based start position.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,422 @@
+//! A backend-neutral syntax tree.
+//!
+//! Rules used to navigate `tree_sitter::Node`/`Tree` directly. That coupled the
+//! whole rule set to tree-sitter's API — in particular to `parent()`,
+//! `next_named_sibling()`, `child_by_field_name()` and node identity via
+//! `id()`, none of which a top-down parser like ZetaSQL/googlesql exposes.
+//!
+//! [`Ast`] decouples the rules from any one parser by *materializing* the tree
+//! into an arena we own. Because we build the arena ourselves, we can populate
+//! parent links, node identity (the arena index) and per-node field names even
+//! for a backend that only hands us children top-down. Today the arena is built
+//! from tree-sitter (see [`Ast::from_tree_sitter`]); a googlesql backend can
+//! populate the same shape later without touching a single rule.
+//!
+//! The arena is a *faithful mirror* of the source tree: every node (named and
+//! anonymous) is kept, with its kind, byte range, 0-based start position, field
+//! name under its parent, parent link and ordered children. [`NodeRef`] offers
+//! the same navigation surface the rules already relied on, so migrating a rule
+//! is a rename rather than a rewrite.
+
+use std::ops::Range;
+
+/// A node's start position in the source, 0-based on both axes.
+///
+/// Mirrors tree-sitter's `Point` (same `row`/`column` field names) so callers
+/// that read `start_position().row` keep working unchanged. Diagnostics convert
+/// to 1-based via [`crate::rules::helpers::one_based_start`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Point {
+    pub row: usize,
+    pub column: usize,
+}
+
+/// One arena entry. Private: navigation goes through [`NodeRef`].
+struct NodeData {
+    kind: String,
+    named: bool,
+    /// The field this node occupies in its parent, if any (tree-sitter field
+    /// names). `None` for anonymous positions and for backends without fields.
+    field_name: Option<String>,
+    byte_range: Range<usize>,
+    start: Point,
+    parent: Option<usize>,
+    children: Vec<usize>,
+}
+
+/// A parsed syntax tree, owned as a flat arena of [`NodeData`].
+///
+/// Index `0` is not assumed to be the root; [`Ast::root`] returns the recorded
+/// root. Rules never see the arena directly — they navigate through
+/// [`NodeRef`], which is a cheap `(arena, index)` handle.
+pub struct Ast {
+    nodes: Vec<NodeData>,
+    root: usize,
+}
+
+impl Ast {
+    /// The root node of the tree.
+    #[must_use]
+    pub const fn root(&self) -> NodeRef<'_> {
+        NodeRef {
+            ast: self,
+            idx: self.root,
+        }
+    }
+
+    /// Every node in pre-order (parent before children, children in order),
+    /// starting at the root. Replaces `traverse(tree.root_node().walk(),
+    /// Order::Pre)`.
+    #[must_use]
+    pub fn pre_order(&self) -> Vec<NodeRef<'_>> {
+        self.root().pre_order()
+    }
+
+    /// Build the arena from a tree-sitter tree, capturing every node with its
+    /// kind, named flag, field name, byte range, start position, parent link
+    /// and ordered children.
+    #[must_use]
+    pub fn from_tree_sitter(tree: &tree_sitter::Tree) -> Self {
+        let mut nodes: Vec<NodeData> = Vec::new();
+        let root = build(tree.root_node(), None, None, &mut nodes);
+        Self { nodes, root }
+    }
+
+    fn get(&self, idx: usize) -> Option<&NodeData> {
+        self.nodes.get(idx)
+    }
+}
+
+/// Recursively add `node` (occupying `field` under `parent`) and its subtree to
+/// `nodes`, returning the new node's arena index.
+fn build(
+    node: tree_sitter::Node<'_>,
+    field: Option<String>,
+    parent: Option<usize>,
+    nodes: &mut Vec<NodeData>,
+) -> usize {
+    let idx = nodes.len();
+    let pos = node.start_position();
+    nodes.push(NodeData {
+        kind: node.kind().to_string(),
+        named: node.is_named(),
+        field_name: field,
+        byte_range: node.start_byte()..node.end_byte(),
+        start: Point {
+            row: pos.row,
+            column: pos.column,
+        },
+        parent,
+        children: Vec::new(),
+    });
+
+    let mut children = Vec::new();
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let field_name = cursor.field_name().map(ToString::to_string);
+            let child_idx = build(cursor.node(), field_name, Some(idx), nodes);
+            children.push(child_idx);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    if let Some(data) = nodes.get_mut(idx) {
+        data.children = children;
+    }
+    idx
+}
+
+/// A cheap, `Copy` handle to one node in an [`Ast`].
+///
+/// Exposes the same navigation the rules relied on under tree-sitter —
+/// `kind`, `parent`, `children`/`named_children`, `child_by_field_name`,
+/// `next_named_sibling`, position and text — so a rule migrates by swapping the
+/// type, not its logic.
+#[derive(Clone, Copy)]
+pub struct NodeRef<'a> {
+    ast: &'a Ast,
+    idx: usize,
+}
+
+impl<'a> NodeRef<'a> {
+    fn data(&self) -> Option<&'a NodeData> {
+        self.ast.get(self.idx)
+    }
+
+    const fn at(&self, idx: usize) -> Self {
+        Self { ast: self.ast, idx }
+    }
+
+    /// Stable identity of this node within its tree. Replaces `Node::id()`;
+    /// two `NodeRef`s are the same node iff their ids are equal.
+    #[must_use]
+    pub const fn id(&self) -> usize {
+        self.idx
+    }
+
+    /// The node's kind (grammar symbol name). Empty string only for a corrupt
+    /// arena, which cannot occur for a `NodeRef` obtained from an `Ast`.
+    #[must_use]
+    pub fn kind(&self) -> &'a str {
+        self.data().map_or("", |d| d.kind.as_str())
+    }
+
+    /// Whether this is a named node (as opposed to an anonymous token).
+    #[must_use]
+    pub fn is_named(&self) -> bool {
+        self.data().is_some_and(|d| d.named)
+    }
+
+    /// The node's byte range in the source.
+    #[must_use]
+    pub fn byte_range(&self) -> Range<usize> {
+        self.data().map_or(0..0, |d| d.byte_range.clone())
+    }
+
+    /// Start byte offset in the source.
+    #[must_use]
+    pub fn start_byte(&self) -> usize {
+        self.byte_range().start
+    }
+
+    /// End byte offset in the source.
+    #[must_use]
+    pub fn end_byte(&self) -> usize {
+        self.byte_range().end
+    }
+
+    /// The node's 0-based start position.
+    #[must_use]
+    pub fn start_position(&self) -> Point {
+        self.data().map_or(Point { row: 0, column: 0 }, |d| d.start)
+    }
+
+    /// The field name this node occupies in its parent, if any.
+    #[must_use]
+    pub fn field_name(&self) -> Option<&'a str> {
+        self.data().and_then(|d| d.field_name.as_deref())
+    }
+
+    /// The node's source text, or `None` if the byte range does not map to a
+    /// valid `&str` slice of `sql` (e.g. a tree/source mismatch that cuts a
+    /// multibyte character). Replaces `Node::utf8_text`.
+    #[must_use]
+    pub fn text<'s>(&self, sql: &'s str) -> Option<&'s str> {
+        sql.get(self.byte_range())
+    }
+
+    /// This node's parent, or `None` at the root.
+    #[must_use]
+    pub fn parent(&self) -> Option<Self> {
+        self.data().and_then(|d| d.parent).map(|p| self.at(p))
+    }
+
+    /// All children in order, including anonymous token nodes. Replaces
+    /// `node.children(&mut node.walk())`.
+    #[must_use]
+    pub fn children(&self) -> Vec<Self> {
+        self.data()
+            .map(|d| d.children.iter().map(|&c| self.at(c)).collect())
+            .unwrap_or_default()
+    }
+
+    /// Named children in order (anonymous tokens skipped). Replaces
+    /// `node.named_children(&mut node.walk())`.
+    #[must_use]
+    pub fn named_children(&self) -> Vec<Self> {
+        self.children().into_iter().filter(Self::is_named).collect()
+    }
+
+    /// The `i`-th child (all children), or `None` if out of range.
+    #[must_use]
+    pub fn child(&self, i: usize) -> Option<Self> {
+        self.data()
+            .and_then(|d| d.children.get(i))
+            .map(|&c| self.at(c))
+    }
+
+    /// The `i`-th named child, or `None` if out of range.
+    #[must_use]
+    pub fn named_child(&self, i: usize) -> Option<Self> {
+        self.named_children().into_iter().nth(i)
+    }
+
+    /// The child occupying the named field `name`, if any. Replaces
+    /// `Node::child_by_field_name`.
+    #[must_use]
+    pub fn child_by_field_name(&self, name: &str) -> Option<Self> {
+        self.children()
+            .into_iter()
+            .find(|c| c.field_name() == Some(name))
+    }
+
+    /// The next named sibling following this node, if any. Replaces
+    /// `Node::next_named_sibling`.
+    #[must_use]
+    pub fn next_named_sibling(&self) -> Option<Self> {
+        let parent = self.parent()?;
+        let siblings = parent.children();
+        let mut after = siblings.into_iter().skip_while(|s| s.id() != self.idx);
+        after.next(); // drop self
+        after.find(Self::is_named)
+    }
+
+    /// This node and its whole subtree in pre-order (self first, then each
+    /// child's subtree in order). Replaces `traverse(node.walk(), Order::Pre)`.
+    #[must_use]
+    pub fn pre_order(&self) -> Vec<Self> {
+        let mut out = Vec::new();
+        let mut stack = vec![*self];
+        while let Some(node) = stack.pop() {
+            out.push(node);
+            // Push children reversed so they pop in source order.
+            let children = node.children();
+            for child in children.into_iter().rev() {
+                stack.push(child);
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    reason = "test code"
+)]
+mod tests {
+    use super::*;
+    use crate::rules::helpers::parse_sql;
+
+    #[test]
+    fn root_and_kinds_mirror_the_source_tree() {
+        // `select a from t` must materialize the expected top-level shape with
+        // tree-sitter's kind names preserved (Phase 1 keeps the vocabulary).
+        let ast = parse_sql("select a from t");
+        let kinds: Vec<&str> = ast.pre_order().iter().map(NodeRef::kind).collect();
+        assert!(kinds.contains(&"select"), "kinds were: {kinds:?}");
+        assert!(kinds.contains(&"identifier"));
+        assert!(kinds.contains(&"from_clause"));
+    }
+
+    #[test]
+    fn pre_order_visits_parent_before_children_in_source_order() {
+        let ast = parse_sql("select a, b from t");
+        let order = ast.pre_order();
+        // The select_list must appear before the identifiers it contains, and
+        // `a` must appear before `b`.
+        let pos = |pred: &dyn Fn(&NodeRef) -> bool| order.iter().position(pred);
+        let list = pos(&|n| n.kind() == "select_list").unwrap();
+        let a = order
+            .iter()
+            .position(|n| n.kind() == "identifier" && n.text("select a, b from t") == Some("a"))
+            .unwrap();
+        let b = order
+            .iter()
+            .position(|n| n.kind() == "identifier" && n.text("select a, b from t") == Some("b"))
+            .unwrap();
+        assert!(list < a && a < b, "list={list} a={a} b={b}");
+    }
+
+    #[test]
+    fn parent_links_point_back_up() {
+        let ast = parse_sql("select a from t");
+        let ident = ast
+            .pre_order()
+            .into_iter()
+            .find(|n| n.kind() == "identifier")
+            .unwrap();
+        // Walking parents must eventually reach a node with no parent (the root).
+        let mut cur = Some(ident);
+        let mut steps = 0;
+        while let Some(n) = cur {
+            cur = n.parent();
+            steps += 1;
+            assert!(steps < 100, "parent chain must terminate");
+        }
+        assert!(steps > 1, "identifier must have ancestors");
+    }
+
+    #[test]
+    fn children_include_anonymous_named_children_do_not() {
+        // A comma-separated select list has anonymous comma tokens between the
+        // named select_expression children; children() sees them, the named
+        // variant does not.
+        let ast = parse_sql("select a, b from t");
+        let list = ast
+            .pre_order()
+            .into_iter()
+            .find(|n| n.kind() == "select_list")
+            .unwrap();
+        assert!(
+            list.children().len() > list.named_children().len(),
+            "anonymous tokens (commas) must be visible via children() only"
+        );
+        assert!(list.named_children().iter().all(NodeRef::is_named));
+    }
+
+    #[test]
+    fn start_position_is_zero_based_and_byte_range_extracts_text() {
+        // `col1` starts at row 0, col 7 (0-based) and its byte range slices back
+        // to "col1".
+        let sql = "SELECT col1 FROM t";
+        let ast = parse_sql(sql);
+        let col1 = ast
+            .pre_order()
+            .into_iter()
+            .find(|n| n.kind() == "identifier" && n.text(sql) == Some("col1"))
+            .unwrap();
+        assert_eq!(col1.start_position(), Point { row: 0, column: 7 });
+        assert_eq!(col1.start_byte(), 7);
+        assert_eq!(col1.end_byte(), 11);
+    }
+
+    #[test]
+    fn text_returns_none_when_range_splits_a_multibyte_char() {
+        // A node's byte range applied to a *different* source that cuts a
+        // multibyte character must yield None, not a panic or garbage.
+        let sql = "SELECT col1 FROM t";
+        let ast = parse_sql(sql);
+        let col1 = ast
+            .pre_order()
+            .into_iter()
+            .find(|n| n.kind() == "identifier" && n.text(sql) == Some("col1"))
+            .unwrap();
+        assert_eq!(col1.byte_range(), 7..11);
+        // byte 10 is the first byte of the 3-byte 'あ', so 7..11 cuts it.
+        assert_eq!(col1.text("abcdefghijあ"), None);
+    }
+
+    #[test]
+    fn next_named_sibling_skips_anonymous_tokens() {
+        let sql = "select a, b from t";
+        let ast = parse_sql(sql);
+        let a = ast
+            .pre_order()
+            .into_iter()
+            .find(|n| n.kind() == "select_expression" && n.text(sql) == Some("a"))
+            .unwrap();
+        let next = a.next_named_sibling().expect("a has a named sibling b");
+        assert_eq!(next.text(sql), Some("b"));
+    }
+
+    #[test]
+    fn id_uniquely_identifies_nodes() {
+        let ast = parse_sql("select a from t");
+        let nodes = ast.pre_order();
+        let root = ast.root();
+        assert_eq!(root.id(), ast.root().id(), "same node -> same id");
+        // Every node in a pre-order walk has a distinct id.
+        let mut ids: Vec<usize> = nodes.iter().map(NodeRef::id).collect();
+        let count = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "ids must be unique");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ast;
 pub mod config;
 pub mod diagnostic;
 pub mod output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use bqvalid::ast::Ast;
 use bqvalid::config::{self, Config};
 use bqvalid::diagnostic::Diagnostic;
 use bqvalid::output::{self, FileResult, OutputFormat};
@@ -193,7 +194,8 @@ fn analyse_sql(parser: &mut TsParser, sql: &str, ignore: &HashSet<String>) -> Ve
         return Vec::new();
     };
 
-    run_rules_ignoring(&tree, sql, ignore)
+    let ast = Ast::from_tree_sitter(&tree);
+    run_rules_ignoring(&ast, sql, ignore)
 }
 
 /// Resolve the effective set of ignored rule ids from the config file and CLI.
@@ -292,8 +294,9 @@ where
   )
 ";
         let tree = parser.parse(sql, None).unwrap();
+        let ast = Ast::from_tree_sitter(&tree);
 
-        let diagnostics = run_rules_ignoring(&tree, sql, &HashSet::new());
+        let diagnostics = run_rules_ignoring(&ast, sql, &HashSet::new());
         assert!(diagnostics.len() > 1);
     }
 

--- a/src/rules/apply_function_to_partition_column.rs
+++ b/src/rules/apply_function_to_partition_column.rs
@@ -1,5 +1,4 @@
-use tree_sitter::Node;
-use tree_sitter_traversal::{Order, traverse};
+use crate::ast::NodeRef;
 
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::helpers::{get_node_text, one_based_start};
@@ -36,11 +35,11 @@ impl Rule for ApplyFunctionToPartitionColumn {
         RULE_ID
     }
 
-    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+    fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if node.kind() != "where_clause" {
             return;
         }
-        for descendant in traverse(node.walk(), Order::Pre) {
+        for descendant in node.pre_order() {
             let operand = match descendant.kind() {
                 // A comparison's left operand is the first child of the
                 // binary/between node (e.g. `date(col) = '...'`,
@@ -60,7 +59,7 @@ impl Rule for ApplyFunctionToPartitionColumn {
 
 /// Returns the offending `function_call` / `cast_expression` node when `operand`
 /// is a date/time transform wrapped around a column reference, else `None`.
-fn date_time_transform_on_column<'a>(operand: &Node<'a>, sql: &str) -> Option<Node<'a>> {
+fn date_time_transform_on_column<'a>(operand: &NodeRef<'a>, sql: &str) -> Option<NodeRef<'a>> {
     match operand.kind() {
         // `function_call`'s first named child is the function name (also an
         // `identifier`), so skip it when looking for a wrapped column.
@@ -80,7 +79,7 @@ fn date_time_transform_on_column<'a>(operand: &Node<'a>, sql: &str) -> Option<No
 }
 
 /// True when the `function_call`'s name is one of [`DATE_TIME_FUNCTIONS`].
-fn is_date_time_function(func: &Node, sql: &str) -> bool {
+fn is_date_time_function(func: &NodeRef<'_>, sql: &str) -> bool {
     func.named_child(0).is_some_and(|name| {
         name.kind() == "identifier"
             && DATE_TIME_FUNCTIONS
@@ -91,9 +90,8 @@ fn is_date_time_function(func: &Node, sql: &str) -> bool {
 
 /// True when the `cast_expression`'s target type is one of
 /// [`DATE_TIME_CAST_TYPES`], e.g. `cast(col as date)`.
-fn casts_to_date_time(cast: &Node, sql: &str) -> bool {
-    let mut cursor = cast.walk();
-    cast.named_children(&mut cursor).any(|child| {
+fn casts_to_date_time(cast: &NodeRef<'_>, sql: &str) -> bool {
+    cast.named_children().into_iter().any(|child| {
         child.kind() == "type_identifier"
             && DATE_TIME_CAST_TYPES
                 .iter()
@@ -106,13 +104,13 @@ fn casts_to_date_time(cast: &Node, sql: &str) -> bool {
 ///
 /// The transform's own name is an `identifier` too, so it is skipped: a column
 /// reference is an `identifier` that is not the function name.
-fn wraps_column(operand: &Node, sql: &str, skip_first_named_child: bool) -> bool {
+fn wraps_column(operand: &NodeRef<'_>, sql: &str, skip_first_named_child: bool) -> bool {
     let skip_id = if skip_first_named_child {
         operand.named_child(0).map(|n| n.id())
     } else {
         None
     };
-    traverse(operand.walk(), Order::Pre).any(|node| {
+    operand.pre_order().into_iter().any(|node| {
         node.kind() == "identifier"
             && Some(node.id()) != skip_id
             && !get_node_text(&node, sql).is_empty()
@@ -120,7 +118,7 @@ fn wraps_column(operand: &Node, sql: &str, skip_first_named_child: bool) -> bool
 }
 
 /// Build the full-scan diagnostic pointing at the offending transform node.
-fn new_full_scan_warning(node: &Node) -> Diagnostic {
+fn new_full_scan_warning(node: &NodeRef<'_>) -> Diagnostic {
     let (row, col) = one_based_start(node);
     Diagnostic::new(
         RULE_ID,

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -1,5 +1,4 @@
-use tree_sitter::Node;
-use tree_sitter_traversal::{Order, traverse};
+use crate::ast::NodeRef;
 
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::helpers::{get_node_text, one_based_start};
@@ -15,7 +14,7 @@ impl Rule for CompareTableSuffixWithSubquery {
         RULE_ID
     }
 
-    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+    fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if node.kind() == "where_clause" {
             if let Some(diagnostic) = compared_with_subquery_in_binary_expression(node, sql) {
                 diagnostics.push(diagnostic);
@@ -27,16 +26,15 @@ impl Rule for CompareTableSuffixWithSubquery {
     }
 }
 
-fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Diagnostic> {
-    for node in traverse(n.walk(), Order::Pre) {
+fn compared_with_subquery_in_binary_expression(n: NodeRef<'_>, src: &str) -> Option<Diagnostic> {
+    for node in n.pre_order() {
         let text = get_node_text(&node, src);
 
         if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
             let Some(parent) = node.parent() else {
                 continue;
             };
-            let mut tc = parent.walk();
-            let Some(right_operand) = parent.children(&mut tc).last() else {
+            let Some(right_operand) = parent.children().into_iter().last() else {
                 continue;
             };
             if parent.kind() == "binary_expression"
@@ -49,8 +47,8 @@ fn compared_with_subquery_in_binary_expression(n: Node, src: &str) -> Option<Dia
     None
 }
 
-fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Diagnostic> {
-    for node in traverse(n.walk(), Order::Pre) {
+fn compared_with_subquery_in_between_expression(n: NodeRef<'_>, src: &str) -> Option<Diagnostic> {
+    for node in n.pre_order() {
         let text = get_node_text(&node, src);
 
         if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
@@ -58,8 +56,7 @@ fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Di
                 continue;
             };
             if parent.kind() == "between_operator" {
-                let mut tc = parent.walk();
-                for c in parent.children(&mut tc) {
+                for c in parent.children() {
                     let Some(first_child) = c.child(0) else {
                         continue;
                     };
@@ -77,7 +74,7 @@ fn compared_with_subquery_in_between_expression(n: Node, src: &str) -> Option<Di
 
 /// Build the full-scan diagnostic pointing at `subquery_node`. Both the binary
 /// and BETWEEN paths report the same problem, so construction lives here.
-fn new_full_scan_warning(subquery_node: &Node) -> Diagnostic {
+fn new_full_scan_warning(subquery_node: &NodeRef<'_>) -> Diagnostic {
     let (row, col) = one_based_start(subquery_node);
     Diagnostic::new(
         RULE_ID,
@@ -109,9 +106,9 @@ select
 from
   dataset.table
 ";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "where_clause" {
                 assert!(compared_with_subquery_in_binary_expression(node, sql).is_none());
                 assert!(compared_with_subquery_in_between_expression(node, sql).is_none());
@@ -131,9 +128,9 @@ where
     select dt from dates
   )
 ";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "where_clause" {
                 assert!(compared_with_subquery_in_binary_expression(node, sql).is_some());
             }
@@ -153,9 +150,9 @@ where
   )
   and '2022-06-01'
 ";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "where_clause" {
                 assert!(compared_with_subquery_in_between_expression(node, sql).is_some());
             }
@@ -175,9 +172,9 @@ where
     select dt from dates
   )
 ";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "where_clause" {
                 assert!(compared_with_subquery_in_between_expression(node, sql).is_some());
             }
@@ -190,10 +187,10 @@ where
         // clause. On this single-line query the subquery starts at the '('.
         let sql = "SELECT x FROM t WHERE _TABLE_SUFFIX = (SELECT MAX(s) FROM u)";
         let paren_col = sql.find('(').expect("query contains a subquery paren");
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
         let mut checked = false;
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "where_clause" {
                 let diagnostic = compared_with_subquery_in_binary_expression(node, sql)
                     .expect("subquery comparison should be flagged");
@@ -213,8 +210,8 @@ where
             "SELECT x FROM t WHERE _TABLE_SUFFIX",
             "WHERE _TABLE_SUFFIX = (",
         ] {
-            let tree = parse_sql(sql);
-            for node in traverse(tree.walk(), Order::Pre) {
+            let ast = parse_sql(sql);
+            for node in ast.pre_order() {
                 if node.kind() == "where_clause" {
                     let _ = compared_with_subquery_in_binary_expression(node, sql);
                     let _ = compared_with_subquery_in_between_expression(node, sql);

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -1,22 +1,22 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
-/// Extract text content from a tree-sitter node, if its byte range maps to
-/// valid UTF-8 within `sql`.
+/// Extract text content from a node, if its byte range maps to valid UTF-8
+/// within `sql`.
 ///
 /// Returns `None` when extraction fails. In normal use `sql` is a valid `&str`
 /// and the node's byte range points into that same source, so this cannot fail;
 /// a `None` therefore signals a corrupted tree or a tree/source mismatch.
-pub fn try_get_node_text<'a>(node: &Node, sql: &'a str) -> Option<&'a str> {
-    node.utf8_text(sql.as_bytes()).ok()
+pub fn try_get_node_text<'a>(node: &NodeRef<'_>, sql: &'a str) -> Option<&'a str> {
+    node.text(sql)
 }
 
-/// Extract text content from a tree-sitter node.
+/// Extract text content from a node.
 ///
 /// On the (practically impossible) extraction failure this logs a warning and
 /// falls back to an empty string, which yields no match downstream (a miss,
 /// never a false positive or a crash). The log makes the resulting false
 /// negative detectable instead of silently swallowing the error.
-pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
+pub fn get_node_text<'a>(node: &NodeRef<'_>, sql: &'a str) -> &'a str {
     try_get_node_text(node, sql).unwrap_or_else(|| {
         let (row, col) = one_based_start(node);
         log::warn!(
@@ -30,27 +30,29 @@ pub fn get_node_text<'a>(node: &Node, sql: &'a str) -> &'a str {
 
 /// 1-based (row, col) of a node's start position.
 ///
-/// tree-sitter reports positions as 0-based; diagnostics report them as 1-based.
+/// The arena reports positions as 0-based; diagnostics report them as 1-based.
 /// This centralizes that `+1` conversion so rules don't each repeat it.
-pub fn one_based_start(node: &Node) -> (usize, usize) {
+pub fn one_based_start(node: &NodeRef<'_>) -> (usize, usize) {
     let point = node.start_position();
     (point.row.saturating_add(1), point.column.saturating_add(1))
 }
 
-/// Find the first child node with the specified kind
-pub fn find_child_of_kind<'a>(node: &'a Node<'a>, kind: &str) -> Option<Node<'a>> {
-    node.named_children(&mut node.walk())
+/// Find the first named child node with the specified kind
+pub fn find_child_of_kind<'a>(node: &NodeRef<'a>, kind: &str) -> Option<NodeRef<'a>> {
+    node.named_children()
+        .into_iter()
         .find(|child| child.kind() == kind)
 }
 
-/// Check if a node has a child with the specified kind
-pub fn has_child_of_kind(node: &Node, kind: &str) -> bool {
-    node.named_children(&mut node.walk())
+/// Check if a node has a named child with the specified kind
+pub fn has_child_of_kind(node: &NodeRef<'_>, kind: &str) -> bool {
+    node.named_children()
+        .into_iter()
         .any(|child| child.kind() == kind)
 }
 
 /// Find the nearest parent node with kind "select"
-pub fn find_parent_select<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
+pub fn find_parent_select<'a>(node: &NodeRef<'a>) -> Option<NodeRef<'a>> {
     let mut current = node.parent();
     while let Some(parent) = current {
         if parent.kind() == "select" {
@@ -62,7 +64,7 @@ pub fn find_parent_select<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
 }
 
 /// Check if a node is a function name (the name part of a function_call)
-pub fn is_function_name(node: &Node) -> bool {
+pub fn is_function_name(node: &NodeRef<'_>) -> bool {
     if let Some(parent) = node.parent()
         && parent.kind() == "function_call"
     {
@@ -76,7 +78,7 @@ pub fn is_function_name(node: &Node) -> bool {
     false
 }
 
-/// Parse SQL string into a tree-sitter tree (test helper)
+/// Parse SQL string into a neutral [`crate::ast::Ast`] (test helper).
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -84,18 +86,19 @@ pub fn is_function_name(node: &Node) -> bool {
     clippy::panic,
     reason = "test code"
 )]
-pub fn parse_sql(sql: &str) -> tree_sitter::Tree {
+pub fn parse_sql(sql: &str) -> crate::ast::Ast {
     use tree_sitter::Parser as TsParser;
     use tree_sitter_sql_bigquery::language;
 
     let mut parser = TsParser::new();
     parser.set_language(&language()).unwrap();
-    parser.parse(sql, None).unwrap()
+    let tree = parser.parse(sql, None).unwrap();
+    crate::ast::Ast::from_tree_sitter(&tree)
 }
 
 /// Parse `sql` and run a single rule over it, returning its diagnostics.
 ///
-/// Collapses the repeated `parse_sql(...)` + `rule.check(&tree, sql)` boilerplate
+/// Collapses the repeated `parse_sql(...)` + `rule.check(&ast, sql)` boilerplate
 /// in rule tests so each case can pass an inline SQL literal and assert on the
 /// result directly.
 #[cfg(test)]
@@ -103,8 +106,8 @@ pub fn run_rule<R: crate::rules::rule::Rule>(
     rule: &R,
     sql: &str,
 ) -> Vec<crate::diagnostic::Diagnostic> {
-    let tree = parse_sql(sql);
-    rule.check(&tree, sql)
+    let ast = parse_sql(sql);
+    rule.check(&ast, sql)
 }
 
 #[cfg(test)]
@@ -118,62 +121,41 @@ pub fn run_rule<R: crate::rules::rule::Rule>(
 )]
 mod tests {
     use super::*;
+    use crate::ast::NodeRef;
+
+    /// The first identifier node in `sql`, for tests that need a concrete node.
+    fn first_identifier(ast: &crate::ast::Ast) -> Option<NodeRef<'_>> {
+        ast.pre_order()
+            .into_iter()
+            .find(|node| node.kind() == "identifier")
+    }
 
     #[test]
     fn test_get_node_text() {
         let sql = "SELECT col1 FROM table1";
-        let tree = parse_sql(sql);
-
-        // Find the first identifier node using traverse
-        use tree_sitter_traversal::{Order, traverse};
-        let mut found = false;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "identifier" {
-                let text = get_node_text(&node, sql);
-                assert!(text == "col1" || text == "table1" || text == "SELECT");
-                found = true;
-                break;
-            }
-        }
-        assert!(found, "Should find at least one identifier");
+        let ast = parse_sql(sql);
+        let node = first_identifier(&ast).expect("Should find at least one identifier");
+        let text = get_node_text(&node, sql);
+        assert!(text == "col1" || text == "table1" || text == "SELECT");
     }
 
     #[test]
     fn try_get_node_text_returns_some_on_valid_source() {
         let sql = "SELECT col1 FROM t";
-        let tree = parse_sql(sql);
-
-        use tree_sitter_traversal::{Order, traverse};
-        let mut checked = false;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "identifier" {
-                assert_eq!(try_get_node_text(&node, sql), Some("col1"));
-                checked = true;
-                break;
-            }
-        }
-        assert!(checked, "expected to find the col1 identifier");
+        let ast = parse_sql(sql);
+        let node = first_identifier(&ast).expect("expected to find the col1 identifier");
+        assert_eq!(try_get_node_text(&node, sql), Some("col1"));
     }
 
     #[test]
     fn try_get_node_text_returns_none_when_range_splits_a_multibyte_char() {
         // Simulate a corrupted tree / source mismatch: extract a node's byte
         // range from a *different* source in which that range slices through a
-        // multibyte character, yielding invalid UTF-8. `utf8_text` then returns
-        // Err and `try_get_node_text` must report the failure as `None` instead
-        // of silently producing an empty string (a hidden false negative).
+        // multibyte character, yielding invalid UTF-8. `text` then returns None
+        // instead of silently producing an empty string (a hidden false negative).
         let sql = "SELECT col1 FROM t";
-        let tree = parse_sql(sql);
-
-        use tree_sitter_traversal::{Order, traverse};
-        let mut ident = None;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "identifier" {
-                ident = Some(node);
-                break;
-            }
-        }
-        let node = ident.expect("expected to find the col1 identifier");
+        let ast = parse_sql(sql);
+        let node = first_identifier(&ast).expect("expected to find the col1 identifier");
         // "col1" occupies bytes 7..11 in `sql`. Build a same-or-longer valid
         // string in which byte 10 is the first byte of a 3-byte character, so
         // that slicing 7..11 cuts it and produces invalid UTF-8.
@@ -188,56 +170,36 @@ mod tests {
         // The public helper keeps its `&str` signature and returns "" on the
         // (logged) failure path, so downstream comparisons simply miss.
         let sql = "SELECT col1 FROM t";
-        let tree = parse_sql(sql);
-
-        use tree_sitter_traversal::{Order, traverse};
-        let mut ident = None;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "identifier" {
-                ident = Some(node);
-                break;
-            }
-        }
-        let node = ident.expect("expected to find the col1 identifier");
+        let ast = parse_sql(sql);
+        let node = first_identifier(&ast).expect("expected to find the col1 identifier");
         let mismatched = "abcdefghijあ";
         assert_eq!(get_node_text(&node, mismatched), "");
     }
 
     #[test]
     fn one_based_start_converts_zero_based_position() {
-        // The single identifier starts at row 0, col 7 (0-based) in tree-sitter;
-        // one_based_start must report it as (1, 8).
+        // The single identifier starts at row 0, col 7 (0-based); one_based_start
+        // must report it as (1, 8).
         let sql = "SELECT col1 FROM t";
-        let tree = parse_sql(sql);
-
-        use tree_sitter_traversal::{Order, traverse};
-        let mut checked = false;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "identifier" && get_node_text(&node, sql) == "col1" {
-                assert_eq!(one_based_start(&node), (1, 8));
-                checked = true;
-                break;
-            }
-        }
-        assert!(checked, "expected to find the col1 identifier");
+        let ast = parse_sql(sql);
+        let node = ast
+            .pre_order()
+            .into_iter()
+            .find(|node| node.kind() == "identifier" && get_node_text(node, sql) == "col1")
+            .expect("expected to find the col1 identifier");
+        assert_eq!(one_based_start(&node), (1, 8));
     }
 
     #[test]
     fn test_find_child_of_kind() {
         let sql = "SELECT col1 FROM table1 GROUP BY col1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
+        let select = ast
+            .pre_order()
+            .into_iter()
+            .find(|node| node.kind() == "select")
+            .expect("Should find select node");
 
-        // Find a select node first, then look for its children
-        use tree_sitter_traversal::{Order, traverse};
-        let mut select_node = None;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "select" {
-                select_node = Some(node);
-                break;
-            }
-        }
-
-        let select = select_node.unwrap();
         // The select node should have a "group_by_clause" child
         let group_by = find_child_of_kind(&select, "group_by_clause");
         assert!(group_by.is_some(), "Should find group_by_clause node");
@@ -250,19 +212,13 @@ mod tests {
     #[test]
     fn test_has_child_of_kind() {
         let sql = "SELECT col1 FROM table1 GROUP BY col1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
+        let select = ast
+            .pre_order()
+            .into_iter()
+            .find(|node| node.kind() == "select")
+            .expect("Should find select node");
 
-        // Find a select node first
-        use tree_sitter_traversal::{Order, traverse};
-        let mut select_node = None;
-        for node in traverse(tree.walk(), Order::Pre) {
-            if node.kind() == "select" {
-                select_node = Some(node);
-                break;
-            }
-        }
-
-        let select = select_node.unwrap();
         // The select node should have a "group_by_clause" child
         assert!(
             has_child_of_kind(&select, "group_by_clause"),

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -1,8 +1,7 @@
 use std::collections::HashSet;
 use std::sync::LazyLock;
-use tree_sitter::Node;
-use tree_sitter_traversal::{Order, traverse};
 
+use crate::ast::NodeRef;
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::helpers::{find_child_of_kind, get_node_text, is_function_name, one_based_start};
 use crate::rules::rule::Rule;
@@ -65,7 +64,7 @@ impl Rule for InvalidGroupBy {
         RULE_ID
     }
 
-    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+    fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if node.kind() == "select"
             && let Some(diags) = check_select(&node, sql)
         {
@@ -74,13 +73,13 @@ impl Rule for InvalidGroupBy {
     }
 }
 
-fn check_select(node: &Node, sql: &str) -> Option<Vec<Diagnostic>> {
+fn check_select(node: &NodeRef<'_>, sql: &str) -> Option<Vec<Diagnostic>> {
     let group_by_columns = extract_group_by_columns(node, sql)?;
 
     let select_list = find_child_of_kind(node, "select_list")?;
 
     let mut diagnostics = Vec::new();
-    for child in select_list.named_children(&mut select_list.walk()) {
+    for child in select_list.named_children() {
         if child.kind() == "select_expression"
             && let Some(diag) = check_select_expression(&child, sql, &group_by_columns)
         {
@@ -95,11 +94,11 @@ fn check_select(node: &Node, sql: &str) -> Option<Vec<Diagnostic>> {
     }
 }
 
-fn extract_group_by_columns(select_node: &Node, sql: &str) -> Option<HashSet<String>> {
+fn extract_group_by_columns(select_node: &NodeRef<'_>, sql: &str) -> Option<HashSet<String>> {
     let group_by_node = find_child_of_kind(select_node, "group_by_clause")?;
     let mut columns = HashSet::new();
 
-    for node in traverse(group_by_node.walk(), Order::Pre) {
+    for node in group_by_node.pre_order() {
         if node.kind() == "identifier" {
             let text = get_node_text(&node, sql);
             columns.insert(text.to_string());
@@ -110,12 +109,12 @@ fn extract_group_by_columns(select_node: &Node, sql: &str) -> Option<HashSet<Str
 }
 
 fn check_select_expression(
-    expr_node: &Node,
+    expr_node: &NodeRef<'_>,
     sql: &str,
     group_by_columns: &HashSet<String>,
 ) -> Option<Diagnostic> {
     // Check if this expression contains an identifier that's not in an aggregate function
-    for node in traverse(expr_node.walk(), Order::Pre) {
+    for node in expr_node.pre_order() {
         if node.kind() == "identifier"
             && !is_alias(&node)
             && !is_function_name(&node)
@@ -143,7 +142,7 @@ fn check_select_expression(
     None
 }
 
-fn is_alias(node: &Node) -> bool {
+fn is_alias(node: &NodeRef<'_>) -> bool {
     // Check if this identifier is part of an as_alias
     if let Some(parent) = node.parent()
         && parent.kind() == "as_alias"
@@ -153,7 +152,7 @@ fn is_alias(node: &Node) -> bool {
     false
 }
 
-fn is_in_aggregate_function(node: &Node, sql: &str) -> bool {
+fn is_in_aggregate_function(node: &NodeRef<'_>, sql: &str) -> bool {
     let mut current = node.parent();
 
     while let Some(parent) = current {
@@ -348,10 +347,10 @@ GROUP BY t1.user_id, t2.category;
     #[test]
     fn test_is_alias() {
         let sql = "SELECT col1 as alias1 FROM table1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
         // Find the identifier "alias1"
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "identifier" {
                 let text = get_node_text(&node, sql);
                 if text == "alias1" {
@@ -369,10 +368,10 @@ GROUP BY t1.user_id, t2.category;
     #[test]
     fn test_is_function_name() {
         let sql = "SELECT COUNT(col1) FROM table1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
         // Check that function names are correctly identified
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "identifier" {
                 let text = get_node_text(&node, sql);
                 if text == "COUNT" {
@@ -393,9 +392,9 @@ GROUP BY t1.user_id, t2.category;
     #[test]
     fn test_is_in_aggregate_function() {
         let sql = "SELECT COUNT(col1), col2 FROM table1 GROUP BY col2";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
 
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             if node.kind() == "identifier" {
                 let text = get_node_text(&node, sql);
                 if text == "col1" {

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -144,12 +144,8 @@ fn check_select_expression(
 
 fn is_alias(node: &NodeRef<'_>) -> bool {
     // Check if this identifier is part of an as_alias
-    if let Some(parent) = node.parent()
-        && parent.kind() == "as_alias"
-    {
-        return true;
-    }
-    false
+    node.parent()
+        .is_some_and(|parent| parent.kind() == "as_alias")
 }
 
 fn is_in_aggregate_function(node: &NodeRef<'_>, sql: &str) -> bool {

--- a/src/rules/rule.rs
+++ b/src/rules/rule.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 
-use tree_sitter::{Node, Tree};
-use tree_sitter_traversal::{Order, traverse};
-
+use crate::ast::{Ast, NodeRef};
 use crate::diagnostic::Diagnostic;
 use crate::rules::{
     apply_function_to_partition_column::ApplyFunctionToPartitionColumn,
@@ -27,21 +25,21 @@ pub trait Rule {
     /// React to a single node visited during the shared pre-order traversal.
     /// Node-driven rules override this; the default does nothing so tree-driven
     /// rules can ignore it.
-    fn check_node(&self, _node: Node<'_>, _sql: &str, _diagnostics: &mut Vec<Diagnostic>) {}
+    fn check_node(&self, _node: NodeRef<'_>, _sql: &str, _diagnostics: &mut Vec<Diagnostic>) {}
 
     /// React to the whole tree, for rules that cannot be expressed per node.
     /// The default does nothing so node-driven rules can ignore it.
-    fn check_tree(&self, _tree: &Tree, _sql: &str, _diagnostics: &mut Vec<Diagnostic>) {}
+    fn check_tree(&self, _ast: &Ast, _sql: &str, _diagnostics: &mut Vec<Diagnostic>) {}
 
-    /// Run this rule alone over `tree`. Convenience for unit tests and callers
+    /// Run this rule alone over `ast`. Convenience for unit tests and callers
     /// that want a single rule's diagnostics; [`run_rules`] shares one traversal
     /// across every rule instead.
-    fn check(&self, tree: &Tree, sql: &str) -> Vec<Diagnostic> {
+    fn check(&self, ast: &Ast, sql: &str) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
-        for node in traverse(tree.walk(), Order::Pre) {
+        for node in ast.pre_order() {
             self.check_node(node, sql, &mut diagnostics);
         }
-        self.check_tree(tree, sql, &mut diagnostics);
+        self.check_tree(ast, sql, &mut diagnostics);
         diagnostics
     }
 }
@@ -66,9 +64,9 @@ pub fn known_rule_ids() -> HashSet<&'static str> {
     all_rules().iter().map(|r| r.id()).collect()
 }
 
-/// Run every registered rule over `tree`, see [`run_rules_ignoring`].
-pub fn run_rules(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
-    run_rules_ignoring(tree, sql, &HashSet::new())
+/// Run every registered rule over `ast`, see [`run_rules_ignoring`].
+pub fn run_rules(ast: &Ast, sql: &str) -> Vec<Diagnostic> {
+    run_rules_ignoring(ast, sql, &HashSet::new())
 }
 
 /// Run the registered rules over `tree` in a single pre-order traversal,
@@ -78,20 +76,20 @@ pub fn run_rules(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
 /// than each rule walking the whole tree on its own. Tree-driven rules run
 /// afterwards. Diagnostics come out in traversal order for the node-driven
 /// rules, followed by the tree-driven ones.
-pub fn run_rules_ignoring(tree: &Tree, sql: &str, ignore: &HashSet<String>) -> Vec<Diagnostic> {
+pub fn run_rules_ignoring(ast: &Ast, sql: &str, ignore: &HashSet<String>) -> Vec<Diagnostic> {
     let rules: Vec<Box<dyn Rule>> = all_rules()
         .into_iter()
         .filter(|rule| !ignore.contains(rule.id()))
         .collect();
     let mut diagnostics = Vec::new();
 
-    for node in traverse(tree.walk(), Order::Pre) {
+    for node in ast.pre_order() {
         for rule in &rules {
             rule.check_node(node, sql, &mut diagnostics);
         }
     }
     for rule in &rules {
-        rule.check_tree(tree, sql, &mut diagnostics);
+        rule.check_tree(ast, sql, &mut diagnostics);
     }
 
     diagnostics

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -25,7 +25,7 @@ impl Rule for UnnecessaryOrderBy {
 }
 
 fn check_unnecessary_order_by_in_scope(scope_node: &NodeRef<'_>, _sql: &str) -> Option<Diagnostic> {
-    let query_expr = find_query_expr(scope_node)?;
+    let query_expr = find_child_of_kind(scope_node, "query_expr")?;
 
     if !has_child_of_kind(&query_expr, "limit_clause")
         && let Some(order_by_node) = find_child_of_kind(&query_expr, "order_by_clause")
@@ -41,12 +41,6 @@ fn check_unnecessary_order_by_in_scope(scope_node: &NodeRef<'_>, _sql: &str) -> 
     }
 
     None
-}
-
-fn find_query_expr<'a>(node: &NodeRef<'a>) -> Option<NodeRef<'a>> {
-    node.named_children()
-        .into_iter()
-        .find(|child| child.kind() == "query_expr")
 }
 
 #[cfg(test)]

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -1,4 +1,4 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::helpers::{find_child_of_kind, has_child_of_kind, one_based_start};
@@ -15,7 +15,7 @@ impl Rule for UnnecessaryOrderBy {
         RULE_ID
     }
 
-    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+    fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if matches!(node.kind(), "cte" | "select_subexpression")
             && let Some(diagnostic) = check_unnecessary_order_by_in_scope(&node, sql)
         {
@@ -24,7 +24,7 @@ impl Rule for UnnecessaryOrderBy {
     }
 }
 
-fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<Diagnostic> {
+fn check_unnecessary_order_by_in_scope(scope_node: &NodeRef<'_>, _sql: &str) -> Option<Diagnostic> {
     let query_expr = find_query_expr(scope_node)?;
 
     if !has_child_of_kind(&query_expr, "limit_clause")
@@ -43,9 +43,10 @@ fn check_unnecessary_order_by_in_scope(scope_node: &Node, _sql: &str) -> Option<
     None
 }
 
-fn find_query_expr<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
-    node.named_children(&mut node.walk())
-        .find(|&child| child.kind() == "query_expr")
+fn find_query_expr<'a>(node: &NodeRef<'a>) -> Option<NodeRef<'a>> {
+    node.named_children()
+        .into_iter()
+        .find(|child| child.kind() == "query_expr")
 }
 
 #[cfg(test)]

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -6,9 +6,7 @@ mod utils;
 mod visitor;
 mod visitors;
 
-use tree_sitter::Tree;
-use tree_sitter_traversal::{Order, traverse};
-
+use crate::ast::Ast;
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::rule::Rule;
 
@@ -32,12 +30,12 @@ impl Rule for UnusedColumnInCte {
         RULE_ID
     }
 
-    fn check_tree(&self, tree: &Tree, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
-        diagnostics.extend(check(tree, sql));
+    fn check_tree(&self, ast: &Ast, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+        diagnostics.extend(check(ast, sql));
     }
 }
 
-pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
+pub fn check(ast: &Ast, sql: &str) -> Vec<Diagnostic> {
     let mut context = AnalysisContext::new(sql);
 
     let cte_visitor = CteVisitor;
@@ -50,13 +48,13 @@ pub fn check(tree: &Tree, sql: &str) -> Vec<Diagnostic> {
     // Single-pass traversal with all visitors
     // Note: DistinctVisitor removed - DISTINCT doesn't make all CTE columns used,
     // only the columns in the SELECT clause are affected by DISTINCT
-    for node in traverse(tree.root_node().walk(), Order::Pre) {
-        cte_visitor.visit(&node, &mut context);
-        select_star_visitor.visit(&node, &mut context);
-        select_visitor.visit(&node, &mut context);
-        where_visitor.visit(&node, &mut context);
-        qualify_visitor.visit(&node, &mut context);
-        pivot_visitor.visit(&node, &mut context);
+    for node in ast.pre_order() {
+        cte_visitor.visit(node, &mut context);
+        select_star_visitor.visit(node, &mut context);
+        select_visitor.visit(node, &mut context);
+        where_visitor.visit(node, &mut context);
+        qualify_visitor.visit(node, &mut context);
+        pivot_visitor.visit(node, &mut context);
     }
 
     context

--- a/src/rules/unused_column_in_cte/utils.rs
+++ b/src/rules/unused_column_in_cte/utils.rs
@@ -94,13 +94,9 @@ impl<'a> TableResolver<'a> {
         alias_map: &'a HashMap<String, String>,
         cte_columns: &HashMap<String, Vec<ColumnInfo>>,
     ) -> Self {
-        let mut is_cte = std::collections::HashSet::new();
+        let is_cte: std::collections::HashSet<String> = cte_columns.keys().cloned().collect();
         let mut unqualified: HashMap<String, &str> = HashMap::new();
         let mut wildcard = None;
-
-        for key in cte_columns.keys() {
-            is_cte.insert(key.clone());
-        }
 
         for table in tables {
             match cte_columns.get(table) {

--- a/src/rules/unused_column_in_cte/utils.rs
+++ b/src/rules/unused_column_in_cte/utils.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use tree_sitter::Node;
-use tree_sitter_traversal::{Order, traverse};
 
+use crate::ast::NodeRef;
 use crate::rules::helpers::{get_node_text, is_function_name};
 
 use super::context::AnalysisContext;
@@ -12,7 +11,7 @@ use super::models::ColumnInfo;
 /// A well-formed CTE always has an `alias_name` field. On a malformed tree
 /// where it is missing we return an empty name rather than panicking; an empty
 /// CTE name simply fails to match downstream lookups.
-pub fn get_cte_name<'a>(cte_node: &Node, sql: &'a str) -> &'a str {
+pub fn get_cte_name<'a>(cte_node: &NodeRef<'_>, sql: &'a str) -> &'a str {
     cte_node
         .child_by_field_name("alias_name")
         .map_or("", |alias_node| get_node_text(&alias_node, sql))
@@ -31,12 +30,15 @@ pub fn extract_table_name(table_ref: &str) -> &str {
 }
 
 /// Extract tables and aliases from a FROM clause
-pub fn extract_table(from: Option<Node>, sql: &str) -> (Vec<String>, HashMap<String, String>) {
+pub fn extract_table(
+    from: Option<NodeRef<'_>>,
+    sql: &str,
+) -> (Vec<String>, HashMap<String, String>) {
     let mut tables = Vec::new();
     let mut alias_map = HashMap::new();
 
     if let Some(from_node) = from {
-        for n in traverse(from_node.walk(), Order::Pre) {
+        for n in from_node.pre_order() {
             if n.kind() == "from_item"
                 && let Some(first_child) = n.named_child(0)
                 && first_child.kind() == "identifier"
@@ -45,9 +47,9 @@ pub fn extract_table(from: Option<Node>, sql: &str) -> (Vec<String>, HashMap<Str
                 tables.push(table_name.clone());
 
                 // Check if there's an alias
-                for child in n.children(&mut n.walk()) {
+                for child in n.children() {
                     if child.kind() == "as_alias" {
-                        if let Some(alias_node) = child.named_children(&mut child.walk()).last() {
+                        if let Some(alias_node) = child.named_children().into_iter().last() {
                             let alias_name = get_node_text(&alias_node, sql).to_string();
                             alias_map.insert(alias_name, table_name.clone());
                         }
@@ -179,7 +181,7 @@ impl<'a> TableResolver<'a> {
 /// Recursively extract all field/identifier references and mark them as used
 /// This function processes field, identifier, and input_column nodes
 pub fn extract_and_mark_fields(
-    node: &Node,
+    node: &NodeRef<'_>,
     sql: &str,
     resolver: &TableResolver,
     context: &mut AnalysisContext,
@@ -203,7 +205,7 @@ pub fn extract_and_mark_fields(
     }
 
     // Recursively process children
-    for child in node.children(&mut node.walk()) {
+    for child in node.children() {
         extract_and_mark_fields(&child, sql, resolver, context);
     }
 }
@@ -397,7 +399,7 @@ mod tests {
     fn get_cte_name_is_empty_for_a_node_without_alias() {
         // A non-CTE node has no `alias_name` field: we must get "" and not panic.
         let sql = "SELECT 1";
-        let tree = parse_sql(sql);
-        assert_eq!(get_cte_name(&tree.root_node(), sql), "");
+        let ast = parse_sql(sql);
+        assert_eq!(get_cte_name(&ast.root(), sql), "");
     }
 }

--- a/src/rules/unused_column_in_cte/visitor.rs
+++ b/src/rules/unused_column_in_cte/visitor.rs
@@ -1,9 +1,9 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
 use super::context::AnalysisContext;
 
 /// Visitor trait for processing AST nodes
 pub trait NodeVisitor {
     /// Visit a node and potentially update the analysis context
-    fn visit(&self, node: &Node, context: &mut AnalysisContext);
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext);
 }

--- a/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
@@ -1,5 +1,5 @@
 use crate::ast::{NodeRef, Point};
-use crate::rules::helpers::get_node_text;
+use crate::rules::helpers::{find_child_of_kind, get_node_text};
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
 };
@@ -24,21 +24,14 @@ impl NodeVisitor for CteVisitor {
 
         if let Some(query) = query_node {
             let select_node = if query.kind() == "query_expr" {
-                query
-                    .named_children()
-                    .into_iter()
-                    .find(|c| c.kind() == "select")
+                find_child_of_kind(&query, "select")
             } else {
                 Some(query)
             };
 
             if let Some(sel) = select_node {
                 // Find the select_list within this SELECT
-                if let Some(select_list) = sel
-                    .named_children()
-                    .into_iter()
-                    .find(|child| child.kind() == "select_list")
-                {
+                if let Some(select_list) = find_child_of_kind(&sel, "select_list") {
                     let columns = extract_columns(&select_list, sql, &context.cte_columns);
                     context.add_cte(cte_name, columns);
                 }

--- a/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
@@ -1,5 +1,4 @@
-use tree_sitter::Node;
-
+use crate::ast::{NodeRef, Point};
 use crate::rules::helpers::get_node_text;
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
@@ -9,23 +8,25 @@ use crate::rules::unused_column_in_cte::{
 pub struct CteVisitor;
 
 impl NodeVisitor for CteVisitor {
-    fn visit(&self, node: &Node, context: &mut AnalysisContext) {
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         if node.kind() != "cte" {
             return;
         }
 
         let sql = context.sql();
-        let cte_name = utils::get_cte_name(node, sql).to_string();
+        let cte_name = utils::get_cte_name(&node, sql).to_string();
 
         // Find the SELECT or query_expr that defines this CTE
         let query_node = node
-            .named_children(&mut node.walk())
+            .named_children()
+            .into_iter()
             .find(|child| child.kind() == "select" || child.kind() == "query_expr");
 
         if let Some(query) = query_node {
             let select_node = if query.kind() == "query_expr" {
                 query
-                    .named_children(&mut query.walk())
+                    .named_children()
+                    .into_iter()
                     .find(|c| c.kind() == "select")
             } else {
                 Some(query)
@@ -34,7 +35,8 @@ impl NodeVisitor for CteVisitor {
             if let Some(sel) = select_node {
                 // Find the select_list within this SELECT
                 if let Some(select_list) = sel
-                    .named_children(&mut sel.walk())
+                    .named_children()
+                    .into_iter()
                     .find(|child| child.kind() == "select_list")
                 {
                     let columns = extract_columns(&select_list, sql, &context.cte_columns);
@@ -50,7 +52,7 @@ impl NodeVisitor for CteVisitor {
 /// Callers always pass the CTE's `select_list`, so this handles that node
 /// directly rather than recursing.
 fn extract_columns(
-    node: &Node,
+    node: &NodeRef<'_>,
     sql: &str,
     cte_columns: &std::collections::HashMap<String, Vec<ColumnInfo>>,
 ) -> Vec<ColumnInfo> {
@@ -64,7 +66,7 @@ fn extract_columns(
     let (tables, alias_map) = utils::extract_table(from, sql);
     let resolver = utils::TableResolver::new(&tables, &alias_map, cte_columns);
 
-    for child in node.children(&mut node.walk()) {
+    for child in node.children() {
         if child.kind() == "select_expression" {
             let column_info = extract_column_info_from_select_expression(&child, sql, &resolver);
             columns.push(column_info);
@@ -79,13 +81,14 @@ fn extract_columns(
 
 /// Extract column information from a select_expression node
 fn extract_column_info_from_select_expression(
-    select_expr: &Node,
+    select_expr: &NodeRef<'_>,
     sql: &str,
     resolver: &utils::TableResolver,
 ) -> ColumnInfo {
     // Check if there's an as_alias child
     let as_alias_node = select_expr
-        .children(&mut select_expr.walk())
+        .children()
+        .into_iter()
         .find(|n| n.kind() == "as_alias");
 
     // Extract column information (with or without alias)
@@ -108,7 +111,7 @@ fn extract_column_info_from_select_expression(
 
 /// Extract column name information when there is no alias
 fn extract_column_name_without_alias(
-    select_expr: &Node,
+    select_expr: &NodeRef<'_>,
     sql: &str,
 ) -> (String, String, Option<String>) {
     let expr = get_node_text(select_expr, sql).to_string();
@@ -123,13 +126,14 @@ fn extract_column_name_without_alias(
 
 /// Extract alias information from an as_alias node
 fn extract_alias_info(
-    alias_node: &Node,
-    select_expr: &Node,
+    alias_node: &NodeRef<'_>,
+    select_expr: &NodeRef<'_>,
     sql: &str,
 ) -> (String, String, Option<String>) {
     // Extract alias name from as_alias node (last named child)
     let alias_name = alias_node
-        .named_children(&mut alias_node.walk())
+        .named_children()
+        .into_iter()
         .last()
         .map(|n| get_node_text(&n, sql).to_string())
         .unwrap_or_default();
@@ -147,7 +151,7 @@ fn extract_alias_info(
 
 /// Expand SELECT * into individual columns
 fn expand_asterisk(
-    position: tree_sitter::Point,
+    position: Point,
     cte_names: &[String],
     cte_columns: &std::collections::HashMap<String, Vec<ColumnInfo>>,
 ) -> Vec<ColumnInfo> {
@@ -178,19 +182,18 @@ fn expand_asterisk(
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use tree_sitter_traversal::{Order, traverse};
 
     #[test]
     fn test_cte_visitor() {
         let sql = "WITH cte1 AS (SELECT col1, col2 FROM table1) SELECT * FROM cte1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let visitor = CteVisitor;
 
         // Visit all nodes
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            visitor.visit(node, &mut context);
         }
 
         assert!(context.has_cte("cte1"));
@@ -203,13 +206,13 @@ mod tests {
     #[test]
     fn test_cte_visitor_with_aliases() {
         let sql = "WITH cte1 AS (SELECT col1 AS alias1, col2 AS alias2, col3 FROM table1) SELECT * FROM cte1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let visitor = CteVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            visitor.visit(node, &mut context);
         }
 
         assert!(context.has_cte("cte1"));
@@ -227,13 +230,13 @@ mod tests {
         let sql = "WITH cte1 AS (SELECT col1, col2, col3 FROM table1), \
                    cte2 AS (SELECT * FROM cte1) \
                    SELECT * FROM cte2";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let visitor = CteVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            visitor.visit(node, &mut context);
         }
 
         // cte1 should have 3 columns
@@ -257,13 +260,13 @@ mod tests {
                    cte2 AS (SELECT user_id, email FROM contacts), \
                    cte3 AS (SELECT order_id, amount FROM orders) \
                    SELECT * FROM cte1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let visitor = CteVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            visitor.visit(node, &mut context);
         }
 
         // All three CTEs should be collected
@@ -290,13 +293,13 @@ mod tests {
     #[test]
     fn test_cte_visitor_with_qualified_names() {
         let sql = "WITH cte1 AS (SELECT t.col1, t.col2 FROM table1 t) SELECT * FROM cte1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let visitor = CteVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            visitor.visit(node, &mut context);
         }
 
         assert!(context.has_cte("cte1"));
@@ -312,13 +315,13 @@ mod tests {
         let sql = "WITH cte1 AS (SELECT col1, col2 FROM table1), \
                    cte2 AS (SELECT *, col3 FROM cte1, table2) \
                    SELECT * FROM cte2";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let visitor = CteVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            visitor.visit(node, &mut context);
         }
 
         assert!(context.has_cte("cte1"));

--- a/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
@@ -1,4 +1,4 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
 use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visitor::NodeVisitor};
 
@@ -7,7 +7,7 @@ use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visito
 pub struct PivotVisitor;
 
 impl NodeVisitor for PivotVisitor {
-    fn visit(&self, node: &Node, context: &mut AnalysisContext) {
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         // Look for PIVOT operator
         if node.kind() != "pivot_operator" {
             return;
@@ -17,17 +17,17 @@ impl NodeVisitor for PivotVisitor {
 
         // Get the FROM clause to know which tables are available
         // Find the parent FROM clause
-        let (tables, alias_map) = find_tables_for_pivot(node, sql);
+        let (tables, alias_map) = find_tables_for_pivot(&node, sql);
         let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
         // Extract all field/identifier references from the PIVOT clause
-        utils::extract_and_mark_fields(node, sql, &resolver, context);
+        utils::extract_and_mark_fields(&node, sql, &resolver, context);
     }
 }
 
 /// Find tables available in the context of a PIVOT operator
 fn find_tables_for_pivot(
-    pivot_node: &Node,
+    pivot_node: &NodeRef<'_>,
     sql: &str,
 ) -> (Vec<String>, std::collections::HashMap<String, String>) {
     // Walk up to find the FROM clause or table reference
@@ -39,7 +39,7 @@ fn find_tables_for_pivot(
         }
         // Check if this is inside a SELECT that has a FROM clause
         if parent.kind() == "select" {
-            for child in parent.named_children(&mut parent.walk()) {
+            for child in parent.named_children() {
                 if child.kind() == "from_clause" {
                     return utils::extract_table(Some(child), sql);
                 }
@@ -62,7 +62,6 @@ fn find_tables_for_pivot(
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use tree_sitter_traversal::{Order, traverse};
 
     use crate::rules::unused_column_in_cte::visitors::{CteVisitor, SelectVisitor};
 
@@ -70,17 +69,17 @@ mod tests {
     fn test_pivot_visitor() {
         let sql = "WITH raw_data AS (SELECT category, month, value, unused FROM table1) \
                    SELECT category FROM raw_data PIVOT(sum(value) for month in ('Jan' as jan))";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let cte_visitor = CteVisitor;
         let select_visitor = SelectVisitor::new();
         let pivot_visitor = PivotVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            cte_visitor.visit(&node, &mut context);
-            select_visitor.visit(&node, &mut context);
-            pivot_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            cte_visitor.visit(node, &mut context);
+            select_visitor.visit(node, &mut context);
+            pivot_visitor.visit(node, &mut context);
         }
 
         // value and month should be marked as used (PIVOT clause)

--- a/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
@@ -38,12 +38,10 @@ fn find_tables_for_pivot(
             return utils::extract_table(Some(parent), sql);
         }
         // Check if this is inside a SELECT that has a FROM clause
-        if parent.kind() == "select" {
-            for child in parent.named_children() {
-                if child.kind() == "from_clause" {
-                    return utils::extract_table(Some(child), sql);
-                }
-            }
+        if parent.kind() == "select"
+            && let Some(from) = crate::rules::helpers::find_child_of_kind(&parent, "from_clause")
+        {
+            return utils::extract_table(Some(from), sql);
         }
         current = parent.parent();
     }

--- a/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
@@ -1,6 +1,6 @@
 use crate::ast::NodeRef;
 
-use crate::rules::helpers::find_parent_select;
+use crate::rules::helpers::{find_child_of_kind, find_parent_select};
 use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visitor::NodeVisitor};
 
 /// Visitor for processing QUALIFY clauses
@@ -21,10 +21,7 @@ impl NodeVisitor for QualifyVisitor {
             return;
         };
 
-        let from_node = select_node
-            .named_children()
-            .into_iter()
-            .find(|child| child.kind() == "from_clause");
+        let from_node = find_child_of_kind(&select_node, "from_clause");
         let (tables, alias_map) = utils::extract_table(from_node, sql);
         let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 

--- a/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
@@ -1,4 +1,4 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
 use crate::rules::helpers::find_parent_select;
 use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visitor::NodeVisitor};
@@ -8,7 +8,7 @@ use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visito
 pub struct QualifyVisitor;
 
 impl NodeVisitor for QualifyVisitor {
-    fn visit(&self, node: &Node, context: &mut AnalysisContext) {
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         // Look for QUALIFY clause
         // BigQuery's QUALIFY is used after SELECT to filter window function results
         if node.kind() != "qualify_clause" {
@@ -17,18 +17,19 @@ impl NodeVisitor for QualifyVisitor {
 
         let sql = context.sql();
 
-        let Some(select_node) = find_parent_select(node) else {
+        let Some(select_node) = find_parent_select(&node) else {
             return;
         };
 
         let from_node = select_node
-            .named_children(&mut select_node.walk())
+            .named_children()
+            .into_iter()
             .find(|child| child.kind() == "from_clause");
         let (tables, alias_map) = utils::extract_table(from_node, sql);
         let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
         // Extract all field/identifier references from the QUALIFY clause
-        utils::extract_and_mark_fields(node, sql, &resolver, context);
+        utils::extract_and_mark_fields(&node, sql, &resolver, context);
     }
 }
 
@@ -44,7 +45,6 @@ impl NodeVisitor for QualifyVisitor {
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use tree_sitter_traversal::{Order, traverse};
 
     use crate::rules::unused_column_in_cte::visitors::{CteVisitor, SelectVisitor};
 
@@ -52,17 +52,17 @@ mod tests {
     fn test_qualify_visitor() {
         let sql = "WITH cte1 AS (SELECT col1, col2, unused FROM table1) \
                    SELECT col2 FROM cte1 QUALIFY row_number() over (partition by col1) = 1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let cte_visitor = CteVisitor;
         let select_visitor = SelectVisitor::new();
         let qualify_visitor = QualifyVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            cte_visitor.visit(&node, &mut context);
-            select_visitor.visit(&node, &mut context);
-            qualify_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            cte_visitor.visit(node, &mut context);
+            select_visitor.visit(node, &mut context);
+            qualify_visitor.visit(node, &mut context);
         }
 
         // col1 should be marked as used (QUALIFY clause)

--- a/src/rules/unused_column_in_cte/visitors/select_star_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_star_visitor.rs
@@ -1,4 +1,4 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
 use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visitor::NodeVisitor};
 
@@ -7,14 +7,15 @@ use crate::rules::unused_column_in_cte::{context::AnalysisContext, utils, visito
 pub struct SelectStarVisitor;
 
 impl NodeVisitor for SelectStarVisitor {
-    fn visit(&self, node: &Node, context: &mut AnalysisContext) {
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         if node.kind() != "select_list" {
             return;
         }
 
         // Check if this select_list contains SELECT *
         let has_select_star = node
-            .children(&mut node.walk())
+            .children()
+            .into_iter()
             .any(|child| child.kind() == "select_all");
 
         if !has_select_star {
@@ -34,13 +35,13 @@ impl NodeVisitor for SelectStarVisitor {
 
         // Only process SELECT * in final SELECT, not in CTEs
         if !in_cte {
-            mark_source_columns_as_used(node, context);
+            mark_source_columns_as_used(&node, context);
         }
     }
 }
 
 /// Mark all columns from source tables as used
-fn mark_source_columns_as_used(select_list: &Node, context: &mut AnalysisContext) {
+fn mark_source_columns_as_used(select_list: &NodeRef<'_>, context: &mut AnalysisContext) {
     let sql = context.sql();
 
     // Find the FROM clause
@@ -73,7 +74,6 @@ fn mark_source_columns_as_used(select_list: &Node, context: &mut AnalysisContext
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use tree_sitter_traversal::{Order, traverse};
 
     use crate::rules::unused_column_in_cte::visitors::{CteVisitor, SelectVisitor};
 
@@ -81,17 +81,17 @@ mod tests {
     fn test_select_star_visitor() {
         let sql = "WITH cte1 AS (SELECT col1, col2, unused FROM table1) \
                    SELECT * FROM cte1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let cte_visitor = CteVisitor;
         let select_star_visitor = SelectStarVisitor;
         let select_visitor = SelectVisitor::new();
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            cte_visitor.visit(&node, &mut context);
-            select_star_visitor.visit(&node, &mut context);
-            select_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            cte_visitor.visit(node, &mut context);
+            select_star_visitor.visit(node, &mut context);
+            select_visitor.visit(node, &mut context);
         }
 
         // All columns should be marked as used (final SELECT *)

--- a/src/rules/unused_column_in_cte/visitors/select_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_visitor.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
-use tree_sitter::Node;
 
+use crate::ast::NodeRef;
 use crate::rules::helpers::{get_node_text, is_function_name};
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
@@ -15,7 +15,7 @@ impl SelectVisitor {
     }
 
     /// Check if we're in the final SELECT (not inside a CTE)
-    fn is_final_select(&self, node: &Node) -> bool {
+    fn is_final_select(&self, node: &NodeRef<'_>) -> bool {
         // Check if this SELECT is inside a CTE
         let mut current = node.parent();
         while let Some(parent) = current {
@@ -29,14 +29,15 @@ impl SelectVisitor {
 }
 
 impl NodeVisitor for SelectVisitor {
-    fn visit(&self, node: &Node, context: &mut AnalysisContext) {
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         if node.kind() == "select" {
             let sql = context.sql();
-            let is_final_select = self.is_final_select(node);
+            let is_final_select = self.is_final_select(&node);
 
             // Find the select_list within the SELECT
             if let Some(select_list) = node
-                .named_children(&mut node.walk())
+                .named_children()
+                .into_iter()
                 .find(|child| child.kind() == "select_list")
             {
                 if is_final_select {
@@ -45,7 +46,7 @@ impl NodeVisitor for SelectVisitor {
                     mark_used_columns(context, final_columns);
                 } else {
                     // For CTE SELECT: extract column references from expressions (e.g., function arguments)
-                    extract_and_mark_expression_columns(&select_list, node, sql, context);
+                    extract_and_mark_expression_columns(&select_list, &node, sql, context);
                 }
             }
         }
@@ -61,8 +62,8 @@ impl Default for SelectVisitor {
 /// Extract column references from CTE SELECT expressions and mark them as used
 /// This handles columns used in function arguments, window functions, etc.
 fn extract_and_mark_expression_columns(
-    select_list: &Node,
-    select_node: &Node,
+    select_list: &NodeRef<'_>,
+    select_node: &NodeRef<'_>,
     sql: &str,
     context: &mut AnalysisContext,
 ) {
@@ -78,7 +79,7 @@ fn extract_and_mark_expression_columns(
     let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
     // Process each select_expression
-    for child in select_list.children(&mut select_list.walk()) {
+    for child in select_list.children() {
         if child.kind() == "select_expression" {
             // Extract all field references from the expression (including nested ones in function calls)
             extract_field_references_from_expression(&child, sql, &resolver, context);
@@ -87,7 +88,7 @@ fn extract_and_mark_expression_columns(
 }
 
 /// Find the CTE name that contains this SELECT node
-fn find_parent_cte_name(select_node: &Node, sql: &str) -> String {
+fn find_parent_cte_name(select_node: &NodeRef<'_>, sql: &str) -> String {
     let mut current = select_node.parent();
     while let Some(parent) = current {
         if parent.kind() == "cte" {
@@ -105,7 +106,7 @@ fn find_parent_cte_name(select_node: &Node, sql: &str) -> String {
 /// Recursively extract all field references from an expression
 /// This handles: direct references, function arguments, window functions, OVER clauses, etc.
 fn extract_field_references_from_expression(
-    node: &Node,
+    node: &NodeRef<'_>,
     sql: &str,
     resolver: &utils::TableResolver,
     context: &mut AnalysisContext,
@@ -128,7 +129,7 @@ fn extract_field_references_from_expression(
     }
 
     // Recursively process children
-    for child in node.children(&mut node.walk()) {
+    for child in node.children() {
         extract_field_references_from_expression(&child, sql, resolver, context);
     }
 }
@@ -136,7 +137,7 @@ fn extract_field_references_from_expression(
 /// Extract columns from final SELECT
 /// This extracts both simple column references and nested field references (e.g., in functions)
 fn extract_final_select_columns(
-    select_list: &Node,
+    select_list: &NodeRef<'_>,
     sql: &str,
     context: &AnalysisContext,
 ) -> Vec<ColumnInfo> {
@@ -145,15 +146,13 @@ fn extract_final_select_columns(
     let (tables, alias_map) = utils::extract_table(from, sql);
     let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
-    for child in select_list.children(&mut select_list.walk()) {
+    for child in select_list.children() {
         if child.kind() == "select_expression" {
             // Strategy: First try to get the direct field reference,
             // then recursively find all field nodes (for function arguments, etc.)
 
             // Check if this has a direct field child (simple column reference)
-            let has_direct_field = child
-                .children(&mut child.walk())
-                .any(|c| c.kind() == "field");
+            let has_direct_field = child.children().into_iter().any(|c| c.kind() == "field");
 
             if !has_direct_field {
                 // Fallback: treat the whole expression text as a column reference
@@ -199,7 +198,7 @@ fn extract_final_select_columns(
 
 /// Recursively extract all 'field' nodes from an AST subtree
 fn extract_all_fields_into_vec(
-    node: &Node,
+    node: &NodeRef<'_>,
     sql: &str,
     resolver: &utils::TableResolver,
     columns: &mut Vec<ColumnInfo>,
@@ -230,7 +229,7 @@ fn extract_all_fields_into_vec(
     }
 
     // Recursively process all children
-    for child in node.children(&mut node.walk()) {
+    for child in node.children() {
         extract_all_fields_into_vec(&child, sql, resolver, columns);
     }
 }
@@ -295,27 +294,26 @@ fn mark_used_columns(context: &mut AnalysisContext, final_columns: Vec<ColumnInf
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use tree_sitter_traversal::{Order, traverse};
 
     #[test]
     fn test_select_visitor() {
         use crate::rules::unused_column_in_cte::visitors::CteVisitor;
 
         let sql = "WITH cte1 AS (SELECT col1, col2, col3 FROM table1) SELECT col1, col2 FROM cte1";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let cte_visitor = CteVisitor;
         let select_visitor = SelectVisitor::new();
 
         // First pass: collect CTEs
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            cte_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            cte_visitor.visit(node, &mut context);
         }
 
         // Second pass: mark usage
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            select_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            select_visitor.visit(node, &mut context);
         }
 
         // Check that col1 and col2 are marked as used

--- a/src/rules/unused_column_in_cte/visitors/select_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_visitor.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use crate::ast::NodeRef;
-use crate::rules::helpers::{get_node_text, is_function_name};
+use crate::rules::helpers::{find_child_of_kind, get_node_text, is_function_name};
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
 };
@@ -35,11 +35,7 @@ impl NodeVisitor for SelectVisitor {
             let is_final_select = self.is_final_select(&node);
 
             // Find the select_list within the SELECT
-            if let Some(select_list) = node
-                .named_children()
-                .into_iter()
-                .find(|child| child.kind() == "select_list")
-            {
+            if let Some(select_list) = find_child_of_kind(&node, "select_list") {
                 if is_final_select {
                     // For final SELECT: extract and mark columns through dependency tracing
                     let final_columns = extract_final_select_columns(&select_list, sql, context);

--- a/src/rules/unused_column_in_cte/visitors/where_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/where_visitor.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use tree_sitter::Node;
-use tree_sitter_traversal::{Order, traverse};
 
+use crate::ast::NodeRef;
 use crate::rules::helpers::{find_parent_select, get_node_text, is_function_name};
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
@@ -11,22 +10,22 @@ use crate::rules::unused_column_in_cte::{
 pub struct WhereVisitor;
 
 impl NodeVisitor for WhereVisitor {
-    fn visit(&self, node: &Node, context: &mut AnalysisContext) {
+    fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         // Process JOIN conditions, WHERE clauses, and GROUP BY
         if matches!(
             node.kind(),
             "join_condition" | "where_clause" | "group_by_clause"
         ) {
-            process_condition_node(node, context);
+            process_condition_node(&node, context);
         } else if node.kind() == "from_clause" {
             // Process UNNEST functions in FROM clause
-            process_unnest_in_from(node, context);
+            process_unnest_in_from(&node, context);
         }
     }
 }
 
 /// Process a condition node and mark column references as used
-fn process_condition_node(node: &Node, context: &mut AnalysisContext) {
+fn process_condition_node(node: &NodeRef<'_>, context: &mut AnalysisContext) {
     let sql = context.sql();
     let (tables, alias_map) = extract_tables_from_parent(node, sql);
     let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
@@ -45,10 +44,14 @@ fn process_condition_node(node: &Node, context: &mut AnalysisContext) {
 }
 
 /// Extract tables from the parent SELECT node
-fn extract_tables_from_parent(node: &Node, sql: &str) -> (Vec<String>, HashMap<String, String>) {
+fn extract_tables_from_parent(
+    node: &NodeRef<'_>,
+    sql: &str,
+) -> (Vec<String>, HashMap<String, String>) {
     if let Some(select_node) = find_parent_select(node) {
         let from_node = select_node
-            .named_children(&mut select_node.walk())
+            .named_children()
+            .into_iter()
             .find(|child| child.kind() == "from_clause");
         return utils::extract_table(from_node, sql);
     }
@@ -56,7 +59,7 @@ fn extract_tables_from_parent(node: &Node, sql: &str) -> (Vec<String>, HashMap<S
 }
 
 /// Process UNNEST functions in FROM clause and mark their column arguments as used
-fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
+fn process_unnest_in_from(from_node: &NodeRef<'_>, context: &mut AnalysisContext) {
     let sql = context.sql();
     let (tables, alias_map) = utils::extract_table(Some(*from_node), sql);
     let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
@@ -65,10 +68,10 @@ fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
     let mut col_refs = Vec::new();
 
     // Find all UNNEST clauses in FROM clause (BigQuery-specific syntax)
-    for child in traverse(from_node.walk(), Order::Pre) {
+    for child in from_node.pre_order() {
         if child.kind() == "unnest_operator" || child.kind() == "unnest_clause" {
             // Extract identifiers from UNNEST - these are the column references
-            for unnest_child in traverse(child.walk(), Order::Pre) {
+            for unnest_child in child.pre_order() {
                 if unnest_child.kind() == "identifier" || unnest_child.kind() == "field" {
                     let column_text = get_node_text(&unnest_child, sql);
                     let table = resolver.resolve_qualified_or(column_text);
@@ -98,13 +101,13 @@ fn process_unnest_in_from(from_node: &Node, context: &mut AnalysisContext) {
 
 /// Extract column references from a condition node
 fn extract_columns_from_condition(
-    node: &Node,
+    node: &NodeRef<'_>,
     sql: &str,
     resolver: &utils::TableResolver,
     columns: &mut Vec<ColumnInfo>,
 ) {
     // Traverse the condition tree to find all column references
-    for child in traverse(node.walk(), Order::Pre) {
+    for child in node.pre_order() {
         if child.kind() == "field" || child.kind() == "identifier" {
             // Skip function names
             if is_function_name(&child) {
@@ -139,7 +142,6 @@ fn extract_columns_from_condition(
 mod tests {
     use super::*;
     use crate::rules::helpers::parse_sql;
-    use tree_sitter_traversal::{Order, traverse};
 
     use crate::rules::unused_column_in_cte::visitors::{CteVisitor, SelectVisitor};
 
@@ -147,7 +149,7 @@ mod tests {
     fn test_where_visitor() {
         let sql = "WITH cte1 AS (SELECT col1, col2, col3 FROM table1) \
                    SELECT col1 FROM cte1 WHERE col2 > 10";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let cte_visitor = CteVisitor;
@@ -155,10 +157,10 @@ mod tests {
         let where_visitor = WhereVisitor;
 
         // Single pass with all visitors
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            cte_visitor.visit(&node, &mut context);
-            select_visitor.visit(&node, &mut context);
-            where_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            cte_visitor.visit(node, &mut context);
+            select_visitor.visit(node, &mut context);
+            where_visitor.visit(node, &mut context);
         }
 
         // col1 should be marked as used (in SELECT)
@@ -178,17 +180,17 @@ mod tests {
                         cte2 AS (SELECT id, value FROM t2) \
                    SELECT cte1.name, cte2.value FROM cte1 \
                    JOIN cte2 ON cte1.id = cte2.id";
-        let tree = parse_sql(sql);
+        let ast = parse_sql(sql);
         let mut context = AnalysisContext::new(sql);
 
         let cte_visitor = CteVisitor;
         let select_visitor = SelectVisitor::new();
         let where_visitor = WhereVisitor;
 
-        for node in traverse(tree.root_node().walk(), Order::Pre) {
-            cte_visitor.visit(&node, &mut context);
-            select_visitor.visit(&node, &mut context);
-            where_visitor.visit(&node, &mut context);
+        for node in ast.pre_order() {
+            cte_visitor.visit(node, &mut context);
+            select_visitor.visit(node, &mut context);
+            where_visitor.visit(node, &mut context);
         }
 
         // name and value should be marked as used (in SELECT)

--- a/src/rules/unused_column_in_cte/visitors/where_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/where_visitor.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use crate::ast::NodeRef;
-use crate::rules::helpers::{find_parent_select, get_node_text, is_function_name};
+use crate::rules::helpers::{
+    find_child_of_kind, find_parent_select, get_node_text, is_function_name,
+};
 use crate::rules::unused_column_in_cte::{
     context::AnalysisContext, models::ColumnInfo, utils, visitor::NodeVisitor,
 };
@@ -49,10 +51,7 @@ fn extract_tables_from_parent(
     sql: &str,
 ) -> (Vec<String>, HashMap<String, String>) {
     if let Some(select_node) = find_parent_select(node) {
-        let from_node = select_node
-            .named_children()
-            .into_iter()
-            .find(|child| child.kind() == "from_clause");
+        let from_node = find_child_of_kind(&select_node, "from_clause");
         return utils::extract_table(from_node, sql);
     }
     (Vec::new(), HashMap::new())

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -1,4 +1,4 @@
-use tree_sitter::Node;
+use crate::ast::NodeRef;
 
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::rules::helpers::{get_node_text, one_based_start};
@@ -14,14 +14,14 @@ impl Rule for UseCurrentDate {
         RULE_ID
     }
 
-    fn check_node(&self, node: Node<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
+    fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
         if let Some(diagnostic) = current_date_used(node, sql) {
             diagnostics.push(diagnostic);
         }
     }
 }
 
-fn current_date_used(node: Node, src: &str) -> Option<Diagnostic> {
+fn current_date_used(node: NodeRef<'_>, src: &str) -> Option<Diagnostic> {
     let text = get_node_text(&node, src);
 
     if node.kind() == "identifier" && text.eq_ignore_ascii_case("current_date") {


### PR DESCRIPTION
## Summary

The **first step of a phased migration** toward swapping the SQL parser (tree-sitter → googlesql/ZetaSQL). It introduces a neutral syntax-tree layer, `src/ast.rs`, to decouple the rule layer from the parser implementation. **This PR keeps the tree-sitter backend**, so behavior is completely unchanged.

## Why

Unlike tree-sitter, the `googlesql` crate (ZetaSQL/WASM) **exposes no parent/sibling/node-id/field-name access — it only walks children top-down**. As long as the rules depend directly on those APIs, the backend cannot be swapped. So we introduce a parser-independent intermediate layer first.

## What changed

- **New `src/ast.rs`**: a neutral AST that materializes the tree-sitter tree into an **owned arena**.
  - `NodeRef` (a `Copy` handle) provides the same navigation surface the rules relied on under tree-sitter: `kind` / `parent` / `children` / `named_children` / `child` / `named_child` / `child_by_field_name` / `next_named_sibling` / `id` / `start_position` / `text` / `pre_order`.
  - Because we build the arena ourselves, we **own the parent links, node identity (arena index), and field names**. This same shape can be reproduced even for a backend that can only walk children top-down.
- Changed the `Rule` trait, `helpers.rs`, `run_rules*`, and `main.rs` to go through `Ast`/`NodeRef` (removing the `tree_sitter::Node`/`Tree` dependency). Traversal moves from `traverse(.., Order::Pre)` to `ast.pre_order()` / `node.pre_order()`.
- Mechanically migrated all 6 rules + the `unused_column_in_cte` submodule + benches (**kind strings and logic unchanged**).
- Kept tree-sitter as the backend (`Ast::from_tree_sitter`). The googlesql backend will plug in here next.

## Verification (all green)

- `cargo fmt --all -- --check`: OK
- `cargo clippy --all-targets -- -D warnings -W clippy::nursery`: No issues
- `cargo test`: **168 passed**
- **plain / JSON output over the real `sql/` corpus is byte-identical to main** (41 diagnostics) → behavior confirmed unchanged

## Next steps (separate PRs)

- Phase 2: add `Ast::from_googlesql` to swap the backend (multi-statement splitting, row/col computation from byte offsets, sequentialization)
- Phase 3: replace kind strings with ZetaSQL AST names and migrate the rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
