### PR TITLE
refactor(parser)!: drop tree-sitter, make googlesql (ZetaSQL) the sole parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,15 +163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "baz-tree-sitter-traversal"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ae77a4ce9f364f49c87fdaf55d1ed79fb301003788acd26b64a46bda8f2a62"
-dependencies = [
- "tree-sitter",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,10 +178,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bqvalid"
 version = "0.0.0"
 dependencies = [
- "baz-tree-sitter-traversal",
  "clap",
  "clap-verbosity-flag",
  "criterion",
@@ -204,8 +203,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
- "tree-sitter",
- "tree-sitter-sql-bigquery",
  "walkdir",
 ]
 
@@ -394,6 +391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +487,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -652,6 +655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,8 +694,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -997,14 +1020,15 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "googlesql"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a5a23ab278f8ddea485996a47cb5076e991d7043b493c61444f077b7c4c879"
+checksum = "945ebcea0b36ba2cbe83fbd1e1b5004fbeb14a39f03912c5a832a717e9ddbc14"
 dependencies = [
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
  "wasmtime",
  "wasmtime-wasi",
+ "zstd",
 ]
 
 [[package]]
@@ -1049,6 +1073,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1928,7 +1961,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2195,26 +2239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tree-sitter"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
-dependencies = [
- "cc",
- "regex",
-]
-
-[[package]]
-name = "tree-sitter-sql-bigquery"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03958a5b10ddcd25ed510cf95a9bbb36cad5837894f4b7743e6ce0e26875e463"
-dependencies = [
- "cc",
- "tree-sitter",
 ]
 
 [[package]]
@@ -2540,7 +2564,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasm-encoder 0.252.0",
@@ -2563,7 +2587,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "toml",
  "wasmtime-environ",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,13 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tree-sitter = "0.22.6"
-tree-sitter-sql-bigquery = "0.8.0"
-baz-tree-sitter-traversal = "0.1.4"
 clap = { version = "4.6.1", features = ["derive"] }
 walkdir = "2.5.0"
 log = "0.4.32"
 env_logger = "0.11.10"
 clap-verbosity-flag = "3.0.4"
 rayon = "1.12.0"
-googlesql = "0.1.0"
+googlesql = { version = "0.3.0", features = ["native-ffi"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.9"

--- a/benches/memory_profile.rs
+++ b/benches/memory_profile.rs
@@ -9,26 +9,22 @@
     reason = "benchmark code"
 )]
 
+use googlesql::Module;
 use std::fs;
-use tree_sitter::Parser as TsParser;
-use tree_sitter_sql_bigquery::language;
 
 use bqvalid::ast::Ast;
 use bqvalid::rules::unused_column_in_cte;
 
-fn parse_sql(sql: &str) -> Ast {
-    let mut parser = TsParser::new();
-    parser.set_language(&language()).unwrap();
-    let tree = parser.parse(sql, None).unwrap();
-    Ast::from_tree_sitter(&tree)
+fn parse_sql(module: &mut Module, sql: &str) -> Ast {
+    Ast::from_googlesql(module, sql).expect("googlesql parses the sql")
 }
 
-fn run_check(name: &str, path: &str) {
+fn run_check(module: &mut Module, name: &str, path: &str) {
     println!("\n=== Running memory profile for: {} ===", name);
 
     let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
 
-    let ast = parse_sql(&sql);
+    let ast = parse_sql(module, &sql);
     let diagnostics = unused_column_in_cte::check(&ast, &sql);
 
     if diagnostics.is_empty() {
@@ -46,9 +42,10 @@ fn main() {
 
     println!("Starting memory profiling...");
 
-    run_check("small", "./benches/fixtures/bench_small.sql");
-    run_check("medium", "./benches/fixtures/bench_medium.sql");
-    run_check("large", "./benches/fixtures/bench_large.sql");
+    let mut module = Module::new_native_ffi().expect("googlesql module builds");
+    run_check(&mut module, "small", "./benches/fixtures/bench_small.sql");
+    run_check(&mut module, "medium", "./benches/fixtures/bench_medium.sql");
+    run_check(&mut module, "large", "./benches/fixtures/bench_large.sql");
 
     println!("\n=== Memory profiling complete ===");
     println!("Results saved to dhat-heap.json");

--- a/benches/unused_column_in_cte.rs
+++ b/benches/unused_column_in_cte.rs
@@ -7,20 +7,16 @@
 )]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use googlesql::Module;
 use std::fs;
 use std::hint::black_box;
-use tree_sitter::Parser as TsParser;
-use tree_sitter_sql_bigquery::language;
 
 // Import the rule check function
 use bqvalid::ast::Ast;
 use bqvalid::rules::unused_column_in_cte;
 
-fn parse_sql(sql: &str) -> Ast {
-    let mut parser = TsParser::new();
-    parser.set_language(&language()).unwrap();
-    let tree = parser.parse(sql, None).unwrap();
-    Ast::from_tree_sitter(&tree)
+fn parse_sql(module: &mut Module, sql: &str) -> Ast {
+    Ast::from_googlesql(module, sql).expect("googlesql parses the sql")
 }
 
 fn bench_unused_column_check(c: &mut Criterion) {
@@ -31,10 +27,11 @@ fn bench_unused_column_check(c: &mut Criterion) {
     ];
 
     let mut group = c.benchmark_group("unused_column_in_cte");
+    let mut module = Module::new_native_ffi().expect("googlesql module builds");
 
     for (name, path) in test_cases {
         let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
-        let ast = parse_sql(&sql);
+        let ast = parse_sql(&mut module, &sql);
 
         group.bench_with_input(
             BenchmarkId::new("check", name),
@@ -59,13 +56,14 @@ fn bench_parse_and_check(c: &mut Criterion) {
     ];
 
     let mut group = c.benchmark_group("parse_and_check");
+    let mut module = Module::new_native_ffi().expect("googlesql module builds");
 
     for (name, path) in test_cases {
         let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
 
         group.bench_with_input(BenchmarkId::new("full", name), &sql, |b, sql| {
             b.iter(|| {
-                let ast = parse_sql(black_box(sql));
+                let ast = parse_sql(&mut module, black_box(sql));
                 let result = unused_column_in_cte::check(black_box(&ast), black_box(sql));
                 black_box(result);
             });

--- a/sql/valid_order_by_with_limit.sql
+++ b/sql/valid_order_by_with_limit.sql
@@ -11,7 +11,7 @@ with top_users as (
 select
   *
 from
-  top_users
+  top_users;
 
 -- Valid: ORDER BY with LIMIT in subquery
 select
@@ -24,7 +24,7 @@ from (
     table1
   order by id
   limit 10
-)
+);
 
 -- Valid: ORDER BY in final SELECT
 select
@@ -32,4 +32,4 @@ select
   name
 from
   table1
-order by id
+order by id;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,22 +1,19 @@
 //! A backend-neutral syntax tree.
 //!
-//! Rules used to navigate `tree_sitter::Node`/`Tree` directly. That coupled the
-//! whole rule set to tree-sitter's API — in particular to `parent()`,
-//! `next_named_sibling()`, `child_by_field_name()` and node identity via
-//! `id()`, none of which a top-down parser like ZetaSQL/googlesql exposes.
+//! Rules navigate through this owned arena rather than a parser's own node type,
+//! so they depend on `parent()`, `next_named_sibling()` and node identity via
+//! `id()` — none of which a top-down parser like ZetaSQL/googlesql exposes
+//! directly.
 //!
-//! [`Ast`] decouples the rules from any one parser by *materializing* the tree
-//! into an arena we own. Because we build the arena ourselves, we can populate
-//! parent links, node identity (the arena index) and per-node field names even
-//! for a backend that only hands us children top-down. Today the arena is built
-//! from tree-sitter (see [`Ast::from_tree_sitter`]); a googlesql backend can
-//! populate the same shape later without touching a single rule.
+//! [`Ast`] decouples the rules from the parser by *materializing* the tree into
+//! an arena we own. Because we build the arena ourselves, we can synthesize
+//! parent links and node identity (the arena index) even for a backend that only
+//! hands us children top-down. The arena is built from googlesql (ZetaSQL); see
+//! [`Ast::from_googlesql`].
 //!
-//! The arena is a *faithful mirror* of the source tree: every node (named and
-//! anonymous) is kept, with its kind, byte range, 0-based start position, field
-//! name under its parent, parent link and ordered children. [`NodeRef`] offers
-//! the same navigation surface the rules already relied on, so migrating a rule
-//! is a rename rather than a rewrite.
+//! The arena is a *faithful mirror* of the source tree: every node is kept, with
+//! its kind, byte range, 0-based start position, parent link and ordered
+//! children. [`NodeRef`] offers a stable navigation surface for the rules.
 
 use std::ops::Range;
 
@@ -24,9 +21,9 @@ use googlesql::{AstNode, Module};
 
 /// A node's start position in the source, 0-based on both axes.
 ///
-/// Mirrors tree-sitter's `Point` (same `row`/`column` field names) so callers
-/// that read `start_position().row` keep working unchanged. Diagnostics convert
-/// to 1-based via [`crate::rules::helpers::one_based_start`].
+/// The `row`/`column` field names let callers read `start_position().row`
+/// directly. Diagnostics convert to 1-based via
+/// [`crate::rules::helpers::one_based_start`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Point {
     pub row: usize,
@@ -37,9 +34,6 @@ pub struct Point {
 struct NodeData {
     kind: String,
     named: bool,
-    /// The field this node occupies in its parent, if any (tree-sitter field
-    /// names). `None` for anonymous positions and for backends without fields.
-    field_name: Option<String>,
     byte_range: Range<usize>,
     start: Point,
     parent: Option<usize>,
@@ -74,90 +68,46 @@ impl Ast {
         self.root().pre_order()
     }
 
-    /// Build the arena from a tree-sitter tree, capturing every node with its
-    /// kind, named flag, field name, byte range, start position, parent link
-    /// and ordered children.
-    #[must_use]
-    pub fn from_tree_sitter(tree: &tree_sitter::Tree) -> Self {
-        let mut nodes: Vec<NodeData> = Vec::new();
-        let root = build(tree.root_node(), None, None, &mut nodes);
-        Self { nodes, root }
-    }
-
     /// Build the arena from a googlesql (ZetaSQL/WASM) parse of a **single**
     /// statement, reusing the given `module` (creating one compiles the WASM,
     /// which is expensive, so callers keep one around).
     ///
-    /// The neutral shape is populated the same way as [`Ast::from_tree_sitter`],
-    /// but from a backend that gives us far less: ZetaSQL exposes only each
-    /// node's kind, its children and an optional byte range — no parent links,
-    /// no node identity, no field names and no row/column. This constructor
-    /// therefore synthesizes the parent links and identity (the arena index),
-    /// derives 0-based positions from the byte offsets, and leaves `field_name`
-    /// empty. Nodes ZetaSQL reports without a byte range (in practice the
-    /// top-level statement/query/select) get a range spanning their located
-    /// children.
+    /// ZetaSQL exposes only each node's kind, its children and an optional byte
+    /// range — no parent links, no node identity and no row/column. This
+    /// constructor therefore synthesizes the parent links and identity (the
+    /// arena index) and derives 0-based positions from the byte offsets. Nodes
+    /// ZetaSQL reports without a byte range (in practice the top-level
+    /// statement/query/select) get a range spanning their located children.
     ///
     /// # Errors
     /// Returns the googlesql [`Error`](googlesql::Error) if the WASM call fails
     /// or the SQL is not exactly one syntactically valid statement (there is no
     /// error recovery and no multi-statement support).
     ///
-    /// Note: the kinds here are ZetaSQL class names (`ASTSelect`, …), not the
-    /// tree-sitter names the current rules match on, so no rule runs against
-    /// this arena yet — wiring it into the analysis path is a later phase.
+    /// The kinds here are ZetaSQL class names (`ASTSelect`, …), which is the
+    /// vocabulary every rule matches on.
     pub fn from_googlesql(module: &mut Module, sql: &str) -> Result<Self, googlesql::Error> {
         let statement = module.parse_statement(sql)?;
+        Ok(Self::from_googlesql_root(statement.root(), sql))
+    }
+
+    /// Build the arena from an already-parsed ZetaSQL statement `root`.
+    ///
+    /// The node byte offsets must be relative to the whole `sql`, which is how
+    /// `Module::parse_statements` reports them for every statement in a
+    /// semicolon-separated script (not just the first). Driving multi-statement
+    /// analysis therefore means calling this once per statement with the shared
+    /// script as `sql`, so row/column stay correct past the first statement.
+    pub fn from_googlesql_root(root: &AstNode, sql: &str) -> Self {
         let line_starts = line_starts(sql);
         let mut nodes: Vec<NodeData> = Vec::new();
-        let root = build_googlesql(statement.root(), None, &line_starts, &mut nodes);
-        Ok(Self { nodes, root })
+        let root = build_googlesql(root, None, &line_starts, &mut nodes);
+        Self { nodes, root }
     }
 
     fn get(&self, idx: usize) -> Option<&NodeData> {
         self.nodes.get(idx)
     }
-}
-
-/// Recursively add `node` (occupying `field` under `parent`) and its subtree to
-/// `nodes`, returning the new node's arena index.
-fn build(
-    node: tree_sitter::Node<'_>,
-    field: Option<String>,
-    parent: Option<usize>,
-    nodes: &mut Vec<NodeData>,
-) -> usize {
-    let idx = nodes.len();
-    let pos = node.start_position();
-    nodes.push(NodeData {
-        kind: node.kind().to_string(),
-        named: node.is_named(),
-        field_name: field,
-        byte_range: node.start_byte()..node.end_byte(),
-        start: Point {
-            row: pos.row,
-            column: pos.column,
-        },
-        parent,
-        children: Vec::new(),
-    });
-
-    let mut children = Vec::new();
-    let mut cursor = node.walk();
-    if cursor.goto_first_child() {
-        loop {
-            let field_name = cursor.field_name().map(ToString::to_string);
-            let child_idx = build(cursor.node(), field_name, Some(idx), nodes);
-            children.push(child_idx);
-            if !cursor.goto_next_sibling() {
-                break;
-            }
-        }
-    }
-    if let Some(data) = nodes.get_mut(idx) {
-        data.children = children;
-    }
-    idx
 }
 
 /// Byte offset of the start of each line in `sql` (line 0 starts at 0). Used to
@@ -174,8 +124,8 @@ fn line_starts(sql: &str) -> Vec<usize> {
 }
 
 /// The 0-based (row, column) of `byte`, where `column` is a byte offset within
-/// the line (matching tree-sitter's `Point`). `starts` must be the ascending
-/// line-start table from [`line_starts`].
+/// the line. `starts` must be the ascending line-start table from
+/// [`line_starts`].
 fn point_at(starts: &[usize], byte: usize) -> Point {
     let row = match starts.binary_search(&byte) {
         // `byte` is exactly a line start: column 0 of that line.
@@ -212,11 +162,8 @@ fn derive_span<'a>(children: impl Iterator<Item = &'a Range<usize>>) -> Option<R
 /// Recursively add the googlesql `node` (under `parent`) and its subtree to
 /// `nodes`, returning the new node's arena index.
 ///
-/// ZetaSQL nodes are all "named" (there are no anonymous token nodes) and carry
-/// no field names, so `named` is always `true` and `field_name` always `None`.
-/// A consequence is that on this backend `named_children()` equals `children()`
-/// and `child_by_field_name()` is always `None` — field-based navigation is
-/// inert until a later phase maps ZetaSQL's typed accessors onto field names.
+/// ZetaSQL nodes are all "named" (there are no anonymous token nodes), so
+/// `named` is always `true` and `named_children()` equals `children()`.
 ///
 /// A node ZetaSQL reports no byte range for gets one spanning its located
 /// children (see [`derive_span`]).
@@ -232,7 +179,6 @@ fn build_googlesql(
     nodes.push(NodeData {
         kind: node.kind().to_string(),
         named: true,
-        field_name: None,
         start: point_at(starts, range.start),
         byte_range: range,
         parent,
@@ -269,10 +215,8 @@ fn build_googlesql(
 
 /// A cheap, `Copy` handle to one node in an [`Ast`].
 ///
-/// Exposes the same navigation the rules relied on under tree-sitter —
-/// `kind`, `parent`, `children`/`named_children`, `child_by_field_name`,
-/// `next_named_sibling`, position and text — so a rule migrates by swapping the
-/// type, not its logic.
+/// Exposes the navigation the rules rely on — `kind`, `parent`,
+/// `children`/`named_children`, `next_named_sibling`, position and text.
 #[derive(Clone, Copy)]
 pub struct NodeRef<'a> {
     ast: &'a Ast,
@@ -332,12 +276,6 @@ impl<'a> NodeRef<'a> {
         self.data().map_or(Point { row: 0, column: 0 }, |d| d.start)
     }
 
-    /// The field name this node occupies in its parent, if any.
-    #[must_use]
-    pub fn field_name(&self) -> Option<&'a str> {
-        self.data().and_then(|d| d.field_name.as_deref())
-    }
-
     /// The node's source text, or `None` if the byte range does not map to a
     /// valid `&str` slice of `sql` (e.g. a tree/source mismatch that cuts a
     /// multibyte character). Replaces `Node::utf8_text`.
@@ -380,15 +318,6 @@ impl<'a> NodeRef<'a> {
     #[must_use]
     pub fn named_child(&self, i: usize) -> Option<Self> {
         self.named_children().into_iter().nth(i)
-    }
-
-    /// The child occupying the named field `name`, if any. Replaces
-    /// `Node::child_by_field_name`.
-    #[must_use]
-    pub fn child_by_field_name(&self, name: &str) -> Option<Self> {
-        self.children()
-            .into_iter()
-            .find(|c| c.field_name() == Some(name))
     }
 
     /// The next named sibling following this node, if any. Replaces
@@ -434,70 +363,40 @@ mod tests {
     use crate::rules::helpers::parse_sql;
 
     #[test]
-    fn root_and_kinds_mirror_the_source_tree() {
-        // `select a from t` must materialize the expected top-level shape with
-        // tree-sitter's kind names preserved (Phase 1 keeps the vocabulary).
-        let ast = parse_sql("select a from t");
-        let kinds: Vec<&str> = ast.pre_order().iter().map(NodeRef::kind).collect();
-        assert!(kinds.contains(&"select"), "kinds were: {kinds:?}");
-        assert!(kinds.contains(&"identifier"));
-        assert!(kinds.contains(&"from_clause"));
-    }
-
-    #[test]
     fn pre_order_visits_parent_before_children_in_source_order() {
-        let ast = parse_sql("select a, b from t");
+        let sql = "select a, b from t";
+        let ast = parse_sql(sql);
         let order = ast.pre_order();
-        // The select_list must appear before the identifiers it contains, and
-        // `a` must appear before `b`.
+        // The select_list must appear before the column references it contains,
+        // and `a` must appear before `b`.
         let pos = |pred: &dyn Fn(&NodeRef) -> bool| order.iter().position(pred);
-        let list = pos(&|n| n.kind() == "select_list").unwrap();
+        let list = pos(&|n| n.kind() == "ASTSelectList").unwrap();
         let a = order
             .iter()
-            .position(|n| n.kind() == "identifier" && n.text("select a, b from t") == Some("a"))
+            .position(|n| n.kind() == "ASTPathExpression" && n.text(sql) == Some("a"))
             .unwrap();
         let b = order
             .iter()
-            .position(|n| n.kind() == "identifier" && n.text("select a, b from t") == Some("b"))
+            .position(|n| n.kind() == "ASTPathExpression" && n.text(sql) == Some("b"))
             .unwrap();
         assert!(list < a && a < b, "list={list} a={a} b={b}");
     }
 
     #[test]
-    fn parent_links_point_back_up() {
-        let ast = parse_sql("select a from t");
-        let ident = ast
-            .pre_order()
-            .into_iter()
-            .find(|n| n.kind() == "identifier")
-            .unwrap();
-        // Walking parents must eventually reach a node with no parent (the root).
-        let mut cur = Some(ident);
-        let mut steps = 0;
-        while let Some(n) = cur {
-            cur = n.parent();
-            steps += 1;
-            assert!(steps < 100, "parent chain must terminate");
-        }
-        assert!(steps > 1, "identifier must have ancestors");
-    }
-
-    #[test]
-    fn children_include_anonymous_named_children_do_not() {
-        // A comma-separated select list has anonymous comma tokens between the
-        // named select_expression children; children() sees them, the named
-        // variant does not.
+    fn every_node_is_named_on_googlesql() {
+        // ZetaSQL emits no anonymous token nodes, so children() and
+        // named_children() coincide for every node (there are no anonymous
+        // tokens such as the commas in a select list).
         let ast = parse_sql("select a, b from t");
-        let list = ast
-            .pre_order()
-            .into_iter()
-            .find(|n| n.kind() == "select_list")
-            .unwrap();
-        assert!(
-            list.children().len() > list.named_children().len(),
-            "anonymous tokens (commas) must be visible via children() only"
-        );
-        assert!(list.named_children().iter().all(NodeRef::is_named));
+        for node in ast.pre_order() {
+            assert!(node.is_named(), "kind {} must be named", node.kind());
+            assert_eq!(
+                node.children().len(),
+                node.named_children().len(),
+                "kind {} must have no anonymous children",
+                node.kind()
+            );
+        }
     }
 
     #[test]
@@ -509,7 +408,7 @@ mod tests {
         let col1 = ast
             .pre_order()
             .into_iter()
-            .find(|n| n.kind() == "identifier" && n.text(sql) == Some("col1"))
+            .find(|n| n.kind() == "ASTPathExpression" && n.text(sql) == Some("col1"))
             .unwrap();
         assert_eq!(col1.start_position(), Point { row: 0, column: 7 });
         assert_eq!(col1.start_byte(), 7);
@@ -525,7 +424,7 @@ mod tests {
         let col1 = ast
             .pre_order()
             .into_iter()
-            .find(|n| n.kind() == "identifier" && n.text(sql) == Some("col1"))
+            .find(|n| n.kind() == "ASTPathExpression" && n.text(sql) == Some("col1"))
             .unwrap();
         assert_eq!(col1.byte_range(), 7..11);
         // byte 10 is the first byte of the 3-byte 'あ', so 7..11 cuts it.
@@ -533,30 +432,18 @@ mod tests {
     }
 
     #[test]
-    fn next_named_sibling_skips_anonymous_tokens() {
+    fn next_named_sibling_walks_to_the_following_column() {
+        // In `select a, b`, the two select columns are siblings under the select
+        // list; next_named_sibling from `a`'s column reaches `b`'s.
         let sql = "select a, b from t";
         let ast = parse_sql(sql);
         let a = ast
             .pre_order()
             .into_iter()
-            .find(|n| n.kind() == "select_expression" && n.text(sql) == Some("a"))
+            .find(|n| n.kind() == "ASTSelectColumn" && n.text(sql) == Some("a"))
             .unwrap();
         let next = a.next_named_sibling().expect("a has a named sibling b");
         assert_eq!(next.text(sql), Some("b"));
-    }
-
-    #[test]
-    fn id_uniquely_identifies_nodes() {
-        let ast = parse_sql("select a from t");
-        let nodes = ast.pre_order();
-        let root = ast.root();
-        assert_eq!(root.id(), ast.root().id(), "same node -> same id");
-        // Every node in a pre-order walk has a distinct id.
-        let mut ids: Vec<usize> = nodes.iter().map(NodeRef::id).collect();
-        let count = ids.len();
-        ids.sort_unstable();
-        ids.dedup();
-        assert_eq!(ids.len(), count, "ids must be unique");
     }
 
     #[test]
@@ -578,9 +465,8 @@ mod tests {
     }
 }
 
-/// Tests for the (dormant) googlesql/ZetaSQL backend. These exercise
-/// [`Ast::from_googlesql`] directly — no rule uses it yet, since ZetaSQL kind
-/// names differ from tree-sitter's (rule migration is Phase 3).
+/// Tests for the googlesql/ZetaSQL backend. These exercise
+/// [`Ast::from_googlesql`] directly, asserting the arena shape ZetaSQL produces.
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -594,31 +480,29 @@ mod googlesql_tests {
     use super::*;
     use googlesql::Module;
 
-    /// A fresh googlesql module. `Module::new()` compiles the ZetaSQL WASM
-    /// (~1s), so each test pays this once; reuse the returned module across as
+    /// A fresh googlesql module on the `native-ffi` backend. Building it links
+    /// the prebuilt ZetaSQL shared library rather than JIT-compiling the wasm, so
+    /// each test pays a small one-time cost; reuse the returned module across as
     /// many parses as the test needs.
     fn module() -> Module {
-        Module::new().expect("load googlesql wasm module")
+        Module::new_native_ffi().expect("load googlesql native-ffi module")
     }
 
     #[test]
     fn from_googlesql_uses_zetasql_kind_names() {
-        // The googlesql arena speaks ZetaSQL's vocabulary (AST* class names),
-        // which is exactly why rules can't run on it until Phase 3.
+        // The googlesql arena speaks ZetaSQL's vocabulary (AST* class names).
         let sql = "select a from t";
         let ast = Ast::from_googlesql(&mut module(), sql).expect("parse");
         let kinds: Vec<&str> = ast.pre_order().iter().map(NodeRef::kind).collect();
         assert!(kinds.contains(&"ASTSelect"), "kinds were: {kinds:?}");
         assert!(kinds.contains(&"ASTFromClause"), "kinds were: {kinds:?}");
         assert!(kinds.contains(&"ASTIdentifier"), "kinds were: {kinds:?}");
-        // And it does NOT speak tree-sitter's vocabulary.
-        assert!(!kinds.contains(&"select"), "kinds were: {kinds:?}");
     }
 
     #[test]
     fn byte_ranges_extract_the_right_source_text() {
         // Every node's byte range must slice back to its own source text, so
-        // rules (later) can read text the same way they do under tree-sitter.
+        // rules can read text from the source directly.
         let sql = "select a from t";
         let ast = Ast::from_googlesql(&mut module(), sql).expect("parse");
         let ident = ast
@@ -668,7 +552,7 @@ mod googlesql_tests {
     #[test]
     fn parent_links_and_ids_are_synthesized() {
         // googlesql exposes no parent links or node identity; the arena
-        // synthesizes both, exactly as it does for tree-sitter.
+        // synthesizes both.
         let sql = "select a from t";
         let ast = Ast::from_googlesql(&mut module(), sql).expect("parse");
         let ident = ast
@@ -703,8 +587,8 @@ mod googlesql_tests {
 
     #[test]
     fn multiple_statements_are_rejected() {
-        // ZetaSQL's parse_statement accepts a single statement only; multi
-        // statement handling is deferred to the backend flip (Phase 3).
+        // ZetaSQL's parse_statement accepts a single statement only; scripts are
+        // driven statement-by-statement via parse_statements in the analysis path.
         let err = Ast::from_googlesql(&mut module(), "select 1; select 2;");
         assert!(err.is_err(), "multiple statements must be rejected");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use bqvalid::output::{self, FileResult, OutputFormat};
 use bqvalid::rules::{known_rule_ids, run_rules_ignoring};
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
+use googlesql::Module;
 use log::debug;
 use rayon::prelude::*;
 use std::collections::HashSet;
@@ -12,8 +13,6 @@ use std::fs;
 use std::io::{self, Read, Stdin};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use tree_sitter::Parser as TsParser;
-use tree_sitter_sql_bigquery::language;
 use walkdir::{DirEntry, WalkDir};
 
 fn get_version() -> &'static str {
@@ -99,8 +98,8 @@ fn main() -> ExitCode {
 }
 
 /// Read SQL from stdin and analyse it as a single `<stdin>` result. Returns
-/// `None` (after logging to stderr) when the input cannot be read or the
-/// grammar fails to load, so the caller can exit with a failure code.
+/// `None` (after logging to stderr) when the input cannot be read or the parser
+/// module fails to load, so the caller can exit with a failure code.
 fn analyse_stdin(stdin: &Stdin, ignore: &HashSet<String>) -> Option<Vec<FileResult>> {
     let mut sql = String::new();
     let read_result = stdin.lock().read_to_string(&mut sql);
@@ -108,10 +107,10 @@ fn analyse_stdin(stdin: &Stdin, ignore: &HashSet<String>) -> Option<Vec<FileResu
         eprintln!("Error reading stdin: {}", e);
         return None;
     }
-    let mut parser = new_parser()?;
+    let mut module = new_module()?;
     Some(vec![FileResult {
         path: PathBuf::from("<stdin>"),
-        diagnostics: analyse_sql(&mut parser, &sql, ignore),
+        diagnostics: analyse_sql_googlesql(&mut module, &sql, ignore),
         read_error: None,
     }])
 }
@@ -146,56 +145,89 @@ fn is_sql(entry: &DirEntry) -> bool {
         .unwrap_or(false)
 }
 
-/// Build a parser with the BigQuery grammar loaded once. Returns `None` if the
-/// grammar fails to load (logged to stderr).
-fn new_parser() -> Option<TsParser> {
-    let mut parser = TsParser::new();
-    match parser.set_language(&language()) {
-        Ok(()) => Some(parser),
+/// Build a googlesql (ZetaSQL) parser module. Returns `None` if the module fails
+/// to initialize (logged to stderr).
+///
+/// Uses the `native-ffi` backend ([`Module::new_native_ffi`]): the ZetaSQL parser
+/// linked as a prebuilt C-ABI shared library and run as native code, rather than
+/// the default wasmtime engine that JIT-compiles the wasm on first use.
+fn new_module() -> Option<Module> {
+    match Module::new_native_ffi() {
+        Ok(module) => Some(module),
         Err(e) => {
-            eprintln!("Error loading BigQuery grammar: {}", e);
+            eprintln!("Error initializing googlesql parser: {}", e);
             None
         }
     }
 }
 
-/// Analyse many files in parallel. Each worker thread builds its parser once
-/// (via `map_init`) and reuses it across the files it handles, so the grammar
-/// is loaded per thread rather than per file. Results are sorted by path so the
-/// output is stable regardless of scheduling.
+/// Analyse many files in parallel. Each worker thread builds its parser module
+/// once (via `map_init`) and reuses it across the files it handles, so the
+/// module is initialized per thread rather than per file. A `None` module means
+/// initialization failed and was already reported; that thread's files then
+/// yield no diagnostics. Results are sorted by path so the output is stable
+/// regardless of scheduling.
+///
+/// The `Module` is large, so it is boxed to keep the per-item closure state
+/// small.
 fn analyse_paths(paths: Vec<PathBuf>, ignore: &HashSet<String>) -> Vec<FileResult> {
     let mut results: Vec<FileResult> = paths
         .par_iter()
-        .map_init(new_parser, |parser, path| match fs::read_to_string(path) {
-            Ok(sql) => {
-                let diagnostics = parser
-                    .as_mut()
-                    .map_or_else(Vec::new, |parser| analyse_sql(parser, &sql, ignore));
-                FileResult {
-                    path: path.clone(),
-                    diagnostics,
-                    read_error: None,
+        .map_init(
+            || new_module().map(Box::new),
+            |module, path| match fs::read_to_string(path) {
+                Ok(sql) => {
+                    let diagnostics = module.as_mut().map_or_else(Vec::new, |module| {
+                        analyse_sql_googlesql(module.as_mut(), &sql, ignore)
+                    });
+                    FileResult {
+                        path: path.clone(),
+                        diagnostics,
+                        read_error: None,
+                    }
                 }
-            }
-            Err(e) => FileResult {
-                path: path.clone(),
-                diagnostics: Vec::new(),
-                read_error: Some(e.to_string()),
+                Err(e) => FileResult {
+                    path: path.clone(),
+                    diagnostics: Vec::new(),
+                    read_error: Some(e.to_string()),
+                },
             },
-        })
+        )
         .collect();
     results.sort_by(|a, b| a.path.cmp(&b.path));
     results
 }
 
-fn analyse_sql(parser: &mut TsParser, sql: &str, ignore: &HashSet<String>) -> Vec<Diagnostic> {
-    let Some(tree) = parser.parse(sql, None) else {
-        eprintln!("Error parsing SQL input");
-        return Vec::new();
+/// Analyse `sql` with the googlesql (ZetaSQL) backend.
+///
+/// ZetaSQL parses one statement at a time and cannot recover past a syntax
+/// error, so `parse_statements` returns every statement it parsed before
+/// stopping plus the error that stopped it. We run the rules over each parsed
+/// statement (byte offsets are relative to the whole script, so positions stay
+/// correct) and report the halting error, if any, to stderr, still emitting
+/// diagnostics for the statements it could parse.
+fn analyse_sql_googlesql(
+    module: &mut Module,
+    sql: &str,
+    ignore: &HashSet<String>,
+) -> Vec<Diagnostic> {
+    let parsed = match module.parse_statements(sql) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            eprintln!("Error parsing SQL input: {}", e);
+            return Vec::new();
+        }
     };
+    if let Some(error) = parsed.error() {
+        eprintln!("Error parsing SQL input: {}", error);
+    }
 
-    let ast = Ast::from_tree_sitter(&tree);
-    run_rules_ignoring(&ast, sql, ignore)
+    let mut diagnostics = Vec::new();
+    for statement in parsed.statements() {
+        let ast = Ast::from_googlesql_root(statement.root(), sql);
+        diagnostics.extend(run_rules_ignoring(&ast, sql, ignore));
+    }
+    diagnostics
 }
 
 /// Resolve the effective set of ignored rule ids from the config file and CLI.
@@ -245,11 +277,32 @@ mod tests {
     use std::fs::{self, File};
     use tempfile::tempdir;
 
-    /// Build a parser and run the full rule set over `sql`, mirroring how the
-    /// binary drives `analyse_sql`.
+    /// Build a googlesql module and run the full rule set over `sql`, mirroring
+    /// how the binary drives `analyse_sql_googlesql`.
     fn analyse(sql: &str) -> Vec<Diagnostic> {
-        let mut parser = new_parser().expect("grammar loads");
-        analyse_sql(&mut parser, sql, &HashSet::new())
+        let mut module = new_module().expect("googlesql module builds");
+        analyse_sql_googlesql(&mut module, sql, &HashSet::new())
+    }
+
+    #[test]
+    fn flags_current_date_end_to_end() {
+        // The whole pipeline (ZetaSQL parse -> neutral AST -> rules) must surface
+        // the use_current_date rule with a 1-based position.
+        let diagnostics = analyse("SELECT CURRENT_DATE() FROM t");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].row(), 1);
+        assert_eq!(diagnostics[0].col(), 8);
+    }
+
+    #[test]
+    fn analyses_every_statement_in_a_script() {
+        // parse_statements recovers at statement boundaries, so a CURRENT_DATE in
+        // the second statement is still flagged, with a position relative to the
+        // whole script (row 2).
+        let sql = "SELECT id FROM a;\nSELECT CURRENT_DATE() FROM b";
+        let diagnostics = analyse(sql);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].row(), 2);
     }
 
     #[test]
@@ -278,9 +331,8 @@ mod tests {
 
     #[test]
     fn multiple_messages_in_single_sql_file() {
-        let mut parser = TsParser::new();
-        parser.set_language(&language()).unwrap();
-
+        // A single statement that trips more than one rule (use_current_date and
+        // compare_table_suffix_with_subquery) yields multiple diagnostics.
         let sql = "\
 select
   current_date,
@@ -293,10 +345,7 @@ where
     select dt from dates
   )
 ";
-        let tree = parser.parse(sql, None).unwrap();
-        let ast = Ast::from_tree_sitter(&tree);
-
-        let diagnostics = run_rules_ignoring(&ast, sql, &HashSet::new());
+        let diagnostics = analyse(sql);
         assert!(diagnostics.len() > 1);
     }
 
@@ -312,13 +361,13 @@ where
     }
 
     #[test]
-    fn analyse_sql_reuses_a_single_parser_across_calls() {
-        // P1: one parser instance handles many inputs without reloading the
-        // grammar. Each parse must stay independent (no state leaking between
-        // calls), so a clean query after a dirty one still yields nothing.
-        let mut parser = new_parser().expect("grammar loads");
-        let dirty = analyse_sql(&mut parser, "SELECT CURRENT_DATE()", &HashSet::new());
-        let clean = analyse_sql(&mut parser, "SELECT id FROM users", &HashSet::new());
+    fn analyse_sql_reuses_a_single_module_across_calls() {
+        // One module instance handles many inputs without reinitializing. Each
+        // parse must stay independent (no state leaking between calls), so a clean
+        // query after a dirty one still yields nothing.
+        let mut module = new_module().expect("googlesql module builds");
+        let dirty = analyse_sql_googlesql(&mut module, "SELECT CURRENT_DATE()", &HashSet::new());
+        let clean = analyse_sql_googlesql(&mut module, "SELECT id FROM users", &HashSet::new());
         assert!(!dirty.is_empty(), "dirty query should produce diagnostics");
         assert!(clean.is_empty(), "clean query should produce none");
     }
@@ -326,7 +375,7 @@ where
     #[test]
     fn analyse_sql_aggregates_multiple_rules_from_a_single_query() {
         // Triggers both use_current_date and compare_table_suffix_with_subquery,
-        // proving analyse_sql fans a query out across every rule and merges results.
+        // proving analysis fans a query out across every rule and merges results.
         let sql = "SELECT CURRENT_DATE() AS d \
                    FROM t \
                    WHERE _TABLE_SUFFIX = (SELECT MAX(suffix) FROM u)";
@@ -356,9 +405,10 @@ where
 
     #[test]
     fn analyse_sql_does_not_panic_on_garbage_input() {
-        // Unparseable input must degrade gracefully (no panic), not crash the tool.
-        let _ = analyse("!@#$ not really ;; SQL (((");
-        let _ = analyse("SELECT FROM WHERE");
+        // Unparseable input must degrade gracefully (the parse error is reported
+        // to stderr and yields no diagnostics), not crash the tool.
+        assert!(analyse("!@#$ not really ;; SQL (((").is_empty());
+        assert!(analyse("SELECT FROM WHERE").is_empty());
     }
 
     #[test]

--- a/src/rules/apply_function_to_partition_column.rs
+++ b/src/rules/apply_function_to_partition_column.rs
@@ -36,7 +36,7 @@ impl Rule for ApplyFunctionToPartitionColumn {
     }
 
     fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
-        if node.kind() != "where_clause" {
+        if node.kind() != "ASTWhereClause" {
             return;
         }
         for descendant in node.pre_order() {
@@ -44,7 +44,7 @@ impl Rule for ApplyFunctionToPartitionColumn {
                 // A comparison's left operand is the first child of the
                 // binary/between node (e.g. `date(col) = '...'`,
                 // `date(col) between '...' and '...'`).
-                "binary_expression" | "between_operator" => descendant.child(0),
+                "ASTBinaryExpression" | "ASTBetweenExpression" => descendant.child(0),
                 _ => continue,
             };
             let Some(operand) = operand else {
@@ -61,15 +61,16 @@ impl Rule for ApplyFunctionToPartitionColumn {
 /// is a date/time transform wrapped around a column reference, else `None`.
 fn date_time_transform_on_column<'a>(operand: &NodeRef<'a>, sql: &str) -> Option<NodeRef<'a>> {
     match operand.kind() {
-        // `function_call`'s first named child is the function name (also an
-        // `identifier`), so skip it when looking for a wrapped column.
-        "function_call"
+        // A function call's first named child is the function name (an
+        // `ASTPathExpression`), so skip it when looking for a wrapped column.
+        "ASTFunctionCall"
             if is_date_time_function(operand, sql) && wraps_column(operand, sql, true) =>
         {
             Some(*operand)
         }
-        // `cast_expression`'s first named child is the operand itself, so keep it.
-        "cast_expression"
+        // A cast's operand is a child too, so keep it; the target type is skipped
+        // inside `wraps_column`.
+        "ASTCastExpression"
             if casts_to_date_time(operand, sql) && wraps_column(operand, sql, false) =>
         {
             Some(*operand)
@@ -78,21 +79,23 @@ fn date_time_transform_on_column<'a>(operand: &NodeRef<'a>, sql: &str) -> Option
     }
 }
 
-/// True when the `function_call`'s name is one of [`DATE_TIME_FUNCTIONS`].
+/// True when the function-call node's name is one of [`DATE_TIME_FUNCTIONS`].
+///
+/// The name node is an `ASTPathExpression` (wrapping the identifier, same text).
 fn is_date_time_function(func: &NodeRef<'_>, sql: &str) -> bool {
     func.named_child(0).is_some_and(|name| {
-        name.kind() == "identifier"
+        name.kind() == "ASTPathExpression"
             && DATE_TIME_FUNCTIONS
                 .iter()
                 .any(|f| f.eq_ignore_ascii_case(get_node_text(&name, sql)))
     })
 }
 
-/// True when the `cast_expression`'s target type is one of
-/// [`DATE_TIME_CAST_TYPES`], e.g. `cast(col as date)`.
+/// True when the cast's target type is one of [`DATE_TIME_CAST_TYPES`], e.g.
+/// `cast(col as date)`. The type node is an `ASTSimpleType` on googlesql.
 fn casts_to_date_time(cast: &NodeRef<'_>, sql: &str) -> bool {
     cast.named_children().into_iter().any(|child| {
-        child.kind() == "type_identifier"
+        child.kind() == "ASTSimpleType"
             && DATE_TIME_CAST_TYPES
                 .iter()
                 .any(|t| t.eq_ignore_ascii_case(get_node_text(&child, sql)))
@@ -102,17 +105,25 @@ fn casts_to_date_time(cast: &NodeRef<'_>, sql: &str) -> bool {
 /// True when the transform is applied to a column reference rather than only
 /// literals, e.g. `date(created_at)` (flagged) vs `date('2024-01-01')` (not).
 ///
-/// The transform's own name is an `identifier` too, so it is skipped: a column
-/// reference is an `identifier` that is not the function name.
+/// A column reference is an `ASTIdentifier` that is neither the transform's own
+/// name nor part of a type. On googlesql both the function name and the cast
+/// target type are themselves `ASTIdentifier`s, so their subtrees are excluded
+/// to avoid mistaking them for a column.
 fn wraps_column(operand: &NodeRef<'_>, sql: &str, skip_first_named_child: bool) -> bool {
-    let skip_id = if skip_first_named_child {
-        operand.named_child(0).map(|n| n.id())
-    } else {
-        None
-    };
+    let mut skip: Vec<usize> = Vec::new();
+    if skip_first_named_child && let Some(name) = operand.named_child(0) {
+        skip.extend(name.pre_order().into_iter().map(|n| n.id()));
+    }
+    for node in operand.pre_order() {
+        // A type node (`cast(col AS date)`) wraps its own identifier on
+        // googlesql; exclude the whole type subtree so it is not read as a column.
+        if node.kind() == "ASTSimpleType" {
+            skip.extend(node.pre_order().into_iter().map(|n| n.id()));
+        }
+    }
     operand.pre_order().into_iter().any(|node| {
-        node.kind() == "identifier"
-            && Some(node.id()) != skip_id
+        node.kind() == "ASTIdentifier"
+            && !skip.contains(&node.id())
             && !get_node_text(&node, sql).is_empty()
     })
 }
@@ -232,11 +243,13 @@ mod tests {
     }
 
     #[test]
-    fn does_not_panic_on_malformed_where_clause() {
+    fn does_not_panic_on_non_comparison_where_shapes() {
+        // WHERE clauses that are not a simple binary/between comparison must not
+        // panic the node navigation (and must not be flagged).
         for sql in [
-            "SELECT x FROM t WHERE DATE(",
-            "SELECT x FROM t WHERE DATE(created_at) =",
-            "WHERE DATE(created_at)",
+            "SELECT x FROM t WHERE is_active",
+            "SELECT x FROM t WHERE created_at IN ('2024-01-01', '2024-01-02')",
+            "SELECT x FROM t WHERE DATE(created_at) IS NOT NULL",
         ] {
             let _ = run_rule(&ApplyFunctionToPartitionColumn, sql);
         }

--- a/src/rules/compare_table_suffix_with_subquery.rs
+++ b/src/rules/compare_table_suffix_with_subquery.rs
@@ -15,7 +15,7 @@ impl Rule for CompareTableSuffixWithSubquery {
     }
 
     fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
-        if node.kind() == "where_clause" {
+        if node.kind() == "ASTWhereClause" {
             if let Some(diagnostic) = compared_with_subquery_in_binary_expression(node, sql) {
                 diagnostics.push(diagnostic);
             }
@@ -26,22 +26,33 @@ impl Rule for CompareTableSuffixWithSubquery {
     }
 }
 
+/// True when `node` is a `_TABLE_SUFFIX` reference: the `ASTPathExpression`
+/// wrapping the identifier on googlesql (whose text is the single name).
+fn is_table_suffix(node: &NodeRef<'_>, src: &str) -> bool {
+    node.kind() == "ASTPathExpression"
+        && get_node_text(node, src).eq_ignore_ascii_case("_table_suffix")
+}
+
+/// True when `node` is a scalar subquery (`ASTExpressionSubquery` on googlesql).
+fn is_subquery(node: &NodeRef<'_>) -> bool {
+    node.kind() == "ASTExpressionSubquery"
+}
+
 fn compared_with_subquery_in_binary_expression(n: NodeRef<'_>, src: &str) -> Option<Diagnostic> {
     for node in n.pre_order() {
-        let text = get_node_text(&node, src);
-
-        if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
-            let Some(parent) = node.parent() else {
-                continue;
-            };
-            let Some(right_operand) = parent.children().into_iter().last() else {
-                continue;
-            };
-            if parent.kind() == "binary_expression"
-                && right_operand.kind() == "select_subexpression"
-            {
-                return Some(new_full_scan_warning(&right_operand));
-            }
+        if node.kind() != "ASTBinaryExpression" {
+            continue;
+        }
+        // `_TABLE_SUFFIX <op> (subquery)`: the left operand is the first child and
+        // the compared-against subquery is the last.
+        let Some(left) = node.child(0) else {
+            continue;
+        };
+        let Some(right) = node.children().into_iter().last() else {
+            continue;
+        };
+        if is_table_suffix(&left, src) && is_subquery(&right) {
+            return Some(new_full_scan_warning(&right));
         }
     }
     None
@@ -49,23 +60,19 @@ fn compared_with_subquery_in_binary_expression(n: NodeRef<'_>, src: &str) -> Opt
 
 fn compared_with_subquery_in_between_expression(n: NodeRef<'_>, src: &str) -> Option<Diagnostic> {
     for node in n.pre_order() {
-        let text = get_node_text(&node, src);
-
-        if node.kind() == "identifier" && text.eq_ignore_ascii_case("_table_suffix") {
-            let Some(parent) = node.parent() else {
-                continue;
-            };
-            if parent.kind() == "between_operator" {
-                for c in parent.children() {
-                    let Some(first_child) = c.child(0) else {
-                        continue;
-                    };
-                    if (c.kind() == "between_from" || c.kind() == "between_to")
-                        && first_child.kind() == "select_subexpression"
-                    {
-                        return Some(new_full_scan_warning(&first_child));
-                    }
-                }
+        if node.kind() != "ASTBetweenExpression" {
+            continue;
+        }
+        let Some(operand) = node.child(0) else {
+            continue;
+        };
+        if !is_table_suffix(&operand, src) {
+            continue;
+        }
+        // googlesql lists the bounds directly under ASTBetweenExpression.
+        for c in node.children() {
+            if is_subquery(&c) {
+                return Some(new_full_scan_warning(&c));
             }
         }
     }
@@ -109,7 +116,7 @@ from
         let ast = parse_sql(sql);
 
         for node in ast.pre_order() {
-            if node.kind() == "where_clause" {
+            if node.kind() == "ASTWhereClause" {
                 assert!(compared_with_subquery_in_binary_expression(node, sql).is_none());
                 assert!(compared_with_subquery_in_between_expression(node, sql).is_none());
             }
@@ -131,7 +138,7 @@ where
         let ast = parse_sql(sql);
 
         for node in ast.pre_order() {
-            if node.kind() == "where_clause" {
+            if node.kind() == "ASTWhereClause" {
                 assert!(compared_with_subquery_in_binary_expression(node, sql).is_some());
             }
         }
@@ -153,7 +160,7 @@ where
         let ast = parse_sql(sql);
 
         for node in ast.pre_order() {
-            if node.kind() == "where_clause" {
+            if node.kind() == "ASTWhereClause" {
                 assert!(compared_with_subquery_in_between_expression(node, sql).is_some());
             }
         }
@@ -175,7 +182,7 @@ where
         let ast = parse_sql(sql);
 
         for node in ast.pre_order() {
-            if node.kind() == "where_clause" {
+            if node.kind() == "ASTWhereClause" {
                 assert!(compared_with_subquery_in_between_expression(node, sql).is_some());
             }
         }
@@ -191,7 +198,7 @@ where
 
         let mut checked = false;
         for node in ast.pre_order() {
-            if node.kind() == "where_clause" {
+            if node.kind() == "ASTWhereClause" {
                 let diagnostic = compared_with_subquery_in_binary_expression(node, sql)
                     .expect("subquery comparison should be flagged");
                 // 1-based, and row 1 because the query is on a single line.
@@ -204,15 +211,26 @@ where
     }
 
     #[test]
-    fn does_not_panic_on_malformed_where_clause() {
-        // Truncated / malformed input must not panic the node-navigation logic.
+    fn comparing_against_a_literal_is_not_flagged() {
+        let sql = "SELECT x FROM t WHERE _TABLE_SUFFIX = '2022-06-01'";
+        let ast = parse_sql(sql);
+        assert!(
+            CompareTableSuffixWithSubquery.check(&ast, sql).is_empty(),
+            "comparing against a literal must not be flagged"
+        );
+    }
+
+    #[test]
+    fn does_not_panic_on_non_subquery_comparisons() {
+        // WHERE shapes that do not compare _TABLE_SUFFIX against a subquery must
+        // not panic the node navigation (and must not be flagged).
         for sql in [
-            "SELECT x FROM t WHERE _TABLE_SUFFIX",
-            "WHERE _TABLE_SUFFIX = (",
+            "SELECT x FROM t WHERE _TABLE_SUFFIX = '2022-06-01'",
+            "SELECT x FROM t WHERE _TABLE_SUFFIX BETWEEN '2022-06-01' AND '2022-06-02'",
         ] {
             let ast = parse_sql(sql);
             for node in ast.pre_order() {
-                if node.kind() == "where_clause" {
+                if node.kind() == "ASTWhereClause" {
                     let _ = compared_with_subquery_in_binary_expression(node, sql);
                     let _ = compared_with_subquery_in_between_expression(node, sql);
                 }

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -51,11 +51,11 @@ pub fn has_child_of_kind(node: &NodeRef<'_>, kind: &str) -> bool {
         .any(|child| child.kind() == kind)
 }
 
-/// Find the nearest parent node with kind "select"
+/// Find the nearest parent SELECT node (`ASTSelect`).
 pub fn find_parent_select<'a>(node: &NodeRef<'a>) -> Option<NodeRef<'a>> {
     let mut current = node.parent();
     while let Some(parent) = current {
-        if parent.kind() == "select" {
+        if parent.kind() == "ASTSelect" {
             return Some(parent);
         }
         current = parent.parent();
@@ -63,22 +63,38 @@ pub fn find_parent_select<'a>(node: &NodeRef<'a>) -> Option<NodeRef<'a>> {
     None
 }
 
-/// Check if a node is a function name (the name part of a function_call)
+/// Check if a node is a function name (the name part of a function call).
+///
+/// On googlesql the name identifier is wrapped in an `ASTPathExpression` that is
+/// the first child of the `ASTFunctionCall`, so the parent is the path
+/// expression rather than the call itself.
 pub fn is_function_name(node: &NodeRef<'_>) -> bool {
-    if let Some(parent) = node.parent()
-        && parent.kind() == "function_call"
-    {
-        if let Some(func_node) = parent.child_by_field_name("function") {
-            return func_node.id() == node.id();
-        }
-        if let Some(first_child) = parent.child(0) {
-            return first_child.id() == node.id();
-        }
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    match parent.kind() {
+        // Name identifier: `ASTFunctionCall -> ASTPathExpression(name) ->
+        // ASTIdentifier` (this node is the identifier).
+        "ASTPathExpression" => parent.parent().is_some_and(|grandparent| {
+            grandparent.kind() == "ASTFunctionCall"
+                && grandparent
+                    .child(0)
+                    .is_some_and(|first| first.id() == parent.id())
+        }),
+        // Name path expression itself: it is the first child of the
+        // `ASTFunctionCall`. (Rules that navigate column references match the
+        // path expression rather than the inner identifier, so this arm skips
+        // the function name in that representation.)
+        "ASTFunctionCall" => parent.child(0).is_some_and(|first| first.id() == node.id()),
+        _ => false,
     }
-    false
 }
 
-/// Parse SQL string into a neutral [`crate::ast::Ast`] (test helper).
+/// Parse `sql` into a neutral [`crate::ast::Ast`] via the googlesql (ZetaSQL)
+/// backend (test helper).
+///
+/// Building a `Module` links the prebuilt ZetaSQL shared library, so keep tests
+/// focused rather than parsing the same SQL many times.
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -87,13 +103,10 @@ pub fn is_function_name(node: &NodeRef<'_>) -> bool {
     reason = "test code"
 )]
 pub fn parse_sql(sql: &str) -> crate::ast::Ast {
-    use tree_sitter::Parser as TsParser;
-    use tree_sitter_sql_bigquery::language;
+    use googlesql::Module;
 
-    let mut parser = TsParser::new();
-    parser.set_language(&language()).unwrap();
-    let tree = parser.parse(sql, None).unwrap();
-    crate::ast::Ast::from_tree_sitter(&tree)
+    let mut module = Module::new_native_ffi().expect("googlesql module builds");
+    crate::ast::Ast::from_googlesql(&mut module, sql).expect("googlesql parses the sql")
 }
 
 /// Parse `sql` and run a single rule over it, returning its diagnostics.
@@ -123,27 +136,28 @@ mod tests {
     use super::*;
     use crate::ast::NodeRef;
 
-    /// The first identifier node in `sql`, for tests that need a concrete node.
-    fn first_identifier(ast: &crate::ast::Ast) -> Option<NodeRef<'_>> {
+    /// The `col1` column-reference node in `sql`, for tests that need a concrete
+    /// node with a known byte range. On googlesql a column reference is an
+    /// `ASTPathExpression` whose text is the (possibly qualified) name.
+    fn col1_ref<'a>(ast: &'a crate::ast::Ast, sql: &str) -> Option<NodeRef<'a>> {
         ast.pre_order()
             .into_iter()
-            .find(|node| node.kind() == "identifier")
+            .find(|node| node.kind() == "ASTPathExpression" && get_node_text(node, sql) == "col1")
     }
 
     #[test]
     fn test_get_node_text() {
         let sql = "SELECT col1 FROM table1";
         let ast = parse_sql(sql);
-        let node = first_identifier(&ast).expect("Should find at least one identifier");
-        let text = get_node_text(&node, sql);
-        assert!(text == "col1" || text == "table1" || text == "SELECT");
+        let node = col1_ref(&ast, sql).expect("Should find the col1 reference");
+        assert_eq!(get_node_text(&node, sql), "col1");
     }
 
     #[test]
     fn try_get_node_text_returns_some_on_valid_source() {
         let sql = "SELECT col1 FROM t";
         let ast = parse_sql(sql);
-        let node = first_identifier(&ast).expect("expected to find the col1 identifier");
+        let node = col1_ref(&ast, sql).expect("expected to find the col1 reference");
         assert_eq!(try_get_node_text(&node, sql), Some("col1"));
     }
 
@@ -155,7 +169,7 @@ mod tests {
         // instead of silently producing an empty string (a hidden false negative).
         let sql = "SELECT col1 FROM t";
         let ast = parse_sql(sql);
-        let node = first_identifier(&ast).expect("expected to find the col1 identifier");
+        let node = col1_ref(&ast, sql).expect("expected to find the col1 reference");
         // "col1" occupies bytes 7..11 in `sql`. Build a same-or-longer valid
         // string in which byte 10 is the first byte of a 3-byte character, so
         // that slicing 7..11 cuts it and produces invalid UTF-8.
@@ -171,22 +185,18 @@ mod tests {
         // (logged) failure path, so downstream comparisons simply miss.
         let sql = "SELECT col1 FROM t";
         let ast = parse_sql(sql);
-        let node = first_identifier(&ast).expect("expected to find the col1 identifier");
+        let node = col1_ref(&ast, sql).expect("expected to find the col1 reference");
         let mismatched = "abcdefghijあ";
         assert_eq!(get_node_text(&node, mismatched), "");
     }
 
     #[test]
     fn one_based_start_converts_zero_based_position() {
-        // The single identifier starts at row 0, col 7 (0-based); one_based_start
-        // must report it as (1, 8).
+        // The single column reference starts at row 0, col 7 (0-based);
+        // one_based_start must report it as (1, 8).
         let sql = "SELECT col1 FROM t";
         let ast = parse_sql(sql);
-        let node = ast
-            .pre_order()
-            .into_iter()
-            .find(|node| node.kind() == "identifier" && get_node_text(node, sql) == "col1")
-            .expect("expected to find the col1 identifier");
+        let node = col1_ref(&ast, sql).expect("expected to find the col1 reference");
         assert_eq!(one_based_start(&node), (1, 8));
     }
 
@@ -197,12 +207,12 @@ mod tests {
         let select = ast
             .pre_order()
             .into_iter()
-            .find(|node| node.kind() == "select")
+            .find(|node| node.kind() == "ASTSelect")
             .expect("Should find select node");
 
-        // The select node should have a "group_by_clause" child
-        let group_by = find_child_of_kind(&select, "group_by_clause");
-        assert!(group_by.is_some(), "Should find group_by_clause node");
+        // The select node should have an ASTGroupBy child
+        let group_by = find_child_of_kind(&select, "ASTGroupBy");
+        assert!(group_by.is_some(), "Should find ASTGroupBy node");
 
         // Should return None for non-existent kind
         let non_existent = find_child_of_kind(&select, "non_existent_kind");
@@ -216,13 +226,13 @@ mod tests {
         let select = ast
             .pre_order()
             .into_iter()
-            .find(|node| node.kind() == "select")
+            .find(|node| node.kind() == "ASTSelect")
             .expect("Should find select node");
 
-        // The select node should have a "group_by_clause" child
+        // The select node should have an ASTGroupBy child
         assert!(
-            has_child_of_kind(&select, "group_by_clause"),
-            "Should have group_by_clause child"
+            has_child_of_kind(&select, "ASTGroupBy"),
+            "Should have ASTGroupBy child"
         );
 
         // Should return false for non-existent kind

--- a/src/rules/invalid_group_by.rs
+++ b/src/rules/invalid_group_by.rs
@@ -65,7 +65,7 @@ impl Rule for InvalidGroupBy {
     }
 
     fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
-        if node.kind() == "select"
+        if node.kind() == "ASTSelect"
             && let Some(diags) = check_select(&node, sql)
         {
             diagnostics.extend(diags);
@@ -76,11 +76,11 @@ impl Rule for InvalidGroupBy {
 fn check_select(node: &NodeRef<'_>, sql: &str) -> Option<Vec<Diagnostic>> {
     let group_by_columns = extract_group_by_columns(node, sql)?;
 
-    let select_list = find_child_of_kind(node, "select_list")?;
+    let select_list = find_child_of_kind(node, "ASTSelectList")?;
 
     let mut diagnostics = Vec::new();
     for child in select_list.named_children() {
-        if child.kind() == "select_expression"
+        if child.kind() == "ASTSelectColumn"
             && let Some(diag) = check_select_expression(&child, sql, &group_by_columns)
         {
             diagnostics.push(diag);
@@ -95,11 +95,11 @@ fn check_select(node: &NodeRef<'_>, sql: &str) -> Option<Vec<Diagnostic>> {
 }
 
 fn extract_group_by_columns(select_node: &NodeRef<'_>, sql: &str) -> Option<HashSet<String>> {
-    let group_by_node = find_child_of_kind(select_node, "group_by_clause")?;
+    let group_by_node = find_child_of_kind(select_node, "ASTGroupBy")?;
     let mut columns = HashSet::new();
 
     for node in group_by_node.pre_order() {
-        if node.kind() == "identifier" {
+        if node.kind() == "ASTIdentifier" {
             let text = get_node_text(&node, sql);
             columns.insert(text.to_string());
         }
@@ -115,7 +115,7 @@ fn check_select_expression(
 ) -> Option<Diagnostic> {
     // Check if this expression contains an identifier that's not in an aggregate function
     for node in expr_node.pre_order() {
-        if node.kind() == "identifier"
+        if node.kind() == "ASTIdentifier"
             && !is_alias(&node)
             && !is_function_name(&node)
             && !is_in_aggregate_function(&node, sql)
@@ -143,22 +143,23 @@ fn check_select_expression(
 }
 
 fn is_alias(node: &NodeRef<'_>) -> bool {
-    // Check if this identifier is part of an as_alias
+    // Check if this identifier is the alias name (`ASTAlias` on googlesql).
     node.parent()
-        .is_some_and(|parent| parent.kind() == "as_alias")
+        .is_some_and(|parent| parent.kind() == "ASTAlias")
 }
 
 fn is_in_aggregate_function(node: &NodeRef<'_>, sql: &str) -> bool {
     let mut current = node.parent();
 
     while let Some(parent) = current {
-        if parent.kind() == "function_call"
-            && let Some(func_node) = parent.child_by_field_name("function")
-        {
-            let func_name = get_node_text(&func_node, sql);
-
-            if AGGREGATE_FUNCTIONS.contains(func_name.to_uppercase().as_str()) {
-                return true;
+        if parent.kind() == "ASTFunctionCall" {
+            // googlesql has no field names, so the function name is the first
+            // child (an `ASTPathExpression` wrapping the name).
+            if let Some(func_node) = parent.child(0) {
+                let func_name = get_node_text(&func_node, sql);
+                if AGGREGATE_FUNCTIONS.contains(func_name.to_uppercase().as_str()) {
+                    return true;
+                }
             }
         }
         current = parent.parent();
@@ -332,26 +333,46 @@ GROUP BY t1.user_id, t2.category;
 "
     )]
     fn test_valid_group_by(#[case] sql: &str) {
+        // Some cases bundle several independent valid statements; googlesql parses
+        // one statement at a time, so run each `;`-separated statement on its own.
+        for statement in sql.split(';').filter(|s| !s.trim().is_empty()) {
+            let diagnostics = run_rule(&InvalidGroupBy, statement);
+            assert!(
+                diagnostics.is_empty(),
+                "Expected no diagnostics for valid GROUP BY, got {} for: {statement}",
+                diagnostics.len()
+            );
+        }
+    }
+
+    #[test]
+    fn points_at_the_ungrouped_column() {
+        let sql = "SELECT col1, col2, COUNT(*) AS cnt FROM my_table GROUP BY col1";
+        let col2 = sql.find("col2").expect("query selects col2");
         let diagnostics = run_rule(&InvalidGroupBy, sql);
-        assert!(
-            diagnostics.is_empty(),
-            "Expected no diagnostics for valid GROUP BY, got {}",
-            diagnostics.len()
-        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].row(), 1);
+        assert_eq!(diagnostics[0].col(), col2 + 1);
     }
 
     #[test]
     fn test_is_alias() {
+        // On googlesql the alias name is an `ASTIdentifier` under an `ASTAlias`,
+        // whereas a column reference's identifier sits under an
+        // `ASTPathExpression`.
         let sql = "SELECT col1 as alias1 FROM table1";
         let ast = parse_sql(sql);
 
-        // Find the identifier "alias1"
+        let mut saw_alias = false;
+        let mut saw_col = false;
         for node in ast.pre_order() {
-            if node.kind() == "identifier" {
+            if node.kind() == "ASTIdentifier" {
                 let text = get_node_text(&node, sql);
                 if text == "alias1" {
+                    saw_alias = true;
                     assert!(is_alias(&node), "alias1 should be recognized as an alias");
                 } else if text == "col1" {
+                    saw_col = true;
                     assert!(
                         !is_alias(&node),
                         "col1 should not be recognized as an alias"
@@ -359,6 +380,7 @@ GROUP BY t1.user_id, t2.category;
                 }
             }
         }
+        assert!(saw_alias && saw_col, "both identifiers must be visited");
     }
 
     #[test]
@@ -367,15 +389,19 @@ GROUP BY t1.user_id, t2.category;
         let ast = parse_sql(sql);
 
         // Check that function names are correctly identified
+        let mut saw_count = false;
+        let mut saw_col = false;
         for node in ast.pre_order() {
-            if node.kind() == "identifier" {
+            if node.kind() == "ASTIdentifier" {
                 let text = get_node_text(&node, sql);
                 if text == "COUNT" {
+                    saw_count = true;
                     assert!(
                         is_function_name(&node),
                         "COUNT should be recognized as a function name"
                     );
                 } else if text == "col1" {
+                    saw_col = true;
                     assert!(
                         !is_function_name(&node),
                         "col1 should not be recognized as a function name"
@@ -383,6 +409,7 @@ GROUP BY t1.user_id, t2.category;
                 }
             }
         }
+        assert!(saw_count && saw_col, "both identifiers must be visited");
     }
 
     #[test]
@@ -390,10 +417,12 @@ GROUP BY t1.user_id, t2.category;
         let sql = "SELECT COUNT(col1), col2 FROM table1 GROUP BY col2";
         let ast = parse_sql(sql);
 
+        let mut saw_col1 = false;
         for node in ast.pre_order() {
-            if node.kind() == "identifier" {
+            if node.kind() == "ASTIdentifier" {
                 let text = get_node_text(&node, sql);
                 if text == "col1" {
+                    saw_col1 = true;
                     assert!(
                         is_in_aggregate_function(&node, sql),
                         "col1 should be recognized as inside aggregate function"
@@ -401,5 +430,6 @@ GROUP BY t1.user_id, t2.category;
                 }
             }
         }
+        assert!(saw_col1, "the col1 identifier must be visited");
     }
 }

--- a/src/rules/unnecessary_order_by.rs
+++ b/src/rules/unnecessary_order_by.rs
@@ -16,7 +16,7 @@ impl Rule for UnnecessaryOrderBy {
     }
 
     fn check_node(&self, node: NodeRef<'_>, sql: &str, diagnostics: &mut Vec<Diagnostic>) {
-        if matches!(node.kind(), "cte" | "select_subexpression")
+        if node.kind() == "ASTQuery"
             && let Some(diagnostic) = check_unnecessary_order_by_in_scope(&node, sql)
         {
             diagnostics.push(diagnostic);
@@ -24,11 +24,36 @@ impl Rule for UnnecessaryOrderBy {
     }
 }
 
-fn check_unnecessary_order_by_in_scope(scope_node: &NodeRef<'_>, _sql: &str) -> Option<Diagnostic> {
-    let query_expr = find_child_of_kind(scope_node, "query_expr")?;
+/// The query body to inspect for an unnecessary ORDER BY, plus the kind names of
+/// its ORDER BY and LIMIT children.
+///
+/// On googlesql the scope is an `ASTQuery` (nested inside a CTE entry or a
+/// subquery) whose direct children are the `ASTOrderBy` / `ASTLimitOffset`; the
+/// top-level query is not a scope, so its trailing ORDER BY (which does have an
+/// effect) is left alone.
+fn scope_query_body<'a>(scope: &NodeRef<'a>) -> Option<(NodeRef<'a>, &'static str, &'static str)> {
+    match scope.kind() {
+        "ASTQuery" if is_nested_query(scope) => Some((*scope, "ASTOrderBy", "ASTLimitOffset")),
+        _ => None,
+    }
+}
 
-    if !has_child_of_kind(&query_expr, "limit_clause")
-        && let Some(order_by_node) = find_child_of_kind(&query_expr, "order_by_clause")
+/// True when an `ASTQuery` is nested inside a CTE entry or a subquery rather than
+/// being the statement's top-level query.
+fn is_nested_query(query: &NodeRef<'_>) -> bool {
+    query.parent().is_some_and(|parent| {
+        matches!(
+            parent.kind(),
+            "ASTAliasedQuery" | "ASTTableSubquery" | "ASTExpressionSubquery"
+        )
+    })
+}
+
+fn check_unnecessary_order_by_in_scope(scope_node: &NodeRef<'_>, _sql: &str) -> Option<Diagnostic> {
+    let (query_body, order_by_kind, limit_kind) = scope_query_body(scope_node)?;
+
+    if !has_child_of_kind(&query_body, limit_kind)
+        && let Some(order_by_node) = find_child_of_kind(&query_body, order_by_kind)
     {
         let (row, col) = one_based_start(&order_by_node);
         return Some(Diagnostic::new(
@@ -101,6 +126,9 @@ where
 
     #[test]
     fn test_valid_order_by_with_limit() {
+        // ORDER BY + LIMIT in a CTE, ORDER BY + LIMIT in a subquery, and a
+        // trailing ORDER BY in the final SELECT are all valid. googlesql requires
+        // `;` between the three statements.
         let sql = "\
 -- Valid: ORDER BY with LIMIT in CTE
 with top_users as (
@@ -115,7 +143,7 @@ with top_users as (
 select
   *
 from
-  top_users
+  top_users;
 
 -- Valid: ORDER BY with LIMIT in subquery
 select
@@ -128,7 +156,7 @@ from (
     table1
   order by id
   limit 10
-)
+);
 
 -- Valid: ORDER BY in final SELECT
 select
@@ -136,9 +164,35 @@ select
   name
 from
   table1
-order by id
+order by id;
 ";
+        // parse_sql handles a single statement; drive each of the three here.
+        for statement in sql.split(';').filter(|s| !s.trim().is_empty()) {
+            let diagnostics = run_rule(&UnnecessaryOrderBy, statement);
+            assert!(
+                diagnostics.is_empty(),
+                "unexpected diagnostics for: {statement}"
+            );
+        }
+    }
+
+    #[test]
+    fn limit_or_final_order_by_is_not_flagged() {
+        // Adding LIMIT to a CTE ORDER BY, or a top-level trailing ORDER BY, is not
+        // flagged.
+        let cte_with_limit = "WITH s AS (SELECT id FROM t ORDER BY id LIMIT 10) SELECT * FROM s";
+        let final_order_by = "SELECT id FROM t ORDER BY id";
+        assert!(run_rule(&UnnecessaryOrderBy, cte_with_limit).is_empty());
+        assert!(run_rule(&UnnecessaryOrderBy, final_order_by).is_empty());
+    }
+
+    #[test]
+    fn points_at_the_order_by_position() {
+        let sql = "WITH s AS (SELECT id FROM t ORDER BY id) SELECT * FROM s";
+        let order_col = sql.find("ORDER").expect("query contains ORDER BY");
         let diagnostics = run_rule(&UnnecessaryOrderBy, sql);
-        assert!(diagnostics.is_empty());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].row(), 1);
+        assert_eq!(diagnostics[0].col(), order_col + 1);
     }
 }

--- a/src/rules/unused_column_in_cte/mod.rs
+++ b/src/rules/unused_column_in_cte/mod.rs
@@ -774,4 +774,56 @@ from
                 .collect::<Vec<_>>()
         );
     }
+
+    /// The whole visitor pipeline must detect unused columns on the googlesql
+    /// (ZetaSQL) backend, exercising each visitor (CTE extraction, final SELECT
+    /// tracing, WHERE, JOIN ON, QUALIFY, PIVOT, UNNEST, SELECT *, aliases, and
+    /// cross-CTE dependency tracing). Cases are single statements because the
+    /// ZetaSQL parser is one statement at a time.
+    #[rstest]
+    // Basic: a CTE column selected by neither the final SELECT nor anything else.
+    #[case("WITH cte1 AS (SELECT col1, col2, unused FROM t) SELECT col1, col2 FROM cte1", vec!["unused"])]
+    // WHERE marks col2 used; col3 stays unused.
+    #[case("WITH cte1 AS (SELECT col1, col2, col3 FROM t) SELECT col1 FROM cte1 WHERE col2 > 10", vec!["col3"])]
+    // JOIN ON marks the id columns used; `unused` stays unused.
+    #[case("WITH cte1 AS (SELECT id, name, unused FROM t1), cte2 AS (SELECT id, value FROM t2) \
+            SELECT cte1.name, cte2.value FROM cte1 JOIN cte2 ON cte1.id = cte2.id", vec!["unused"])]
+    // QUALIFY marks col1 used (window partition); `unused` stays unused.
+    #[case("WITH cte1 AS (SELECT col1, col2, unused FROM t) \
+            SELECT col2 FROM cte1 QUALIFY row_number() over (partition by col1) = 1", vec!["unused"])]
+    // PIVOT marks value/month used; `unused` stays unused.
+    #[case("WITH raw_data AS (SELECT category, month, value, unused FROM t) \
+            SELECT category FROM raw_data PIVOT(sum(value) FOR month IN ('Jan' AS jan))", vec!["unused"])]
+    // Alias + GROUP BY: unique_id is used; column2 and unused_column are not.
+    #[case("WITH cte1 AS (SELECT column1 AS unique_id, column2, unused_column FROM t) \
+            SELECT unique_id, count(*) FROM cte1 GROUP BY unique_id", vec!["column2", "unused_column"])]
+    // Cross-CTE tracing: final uses d2.k1 (-> d1.k1); d1.orphan and d2.k2 stay unused.
+    #[case("WITH d1 AS (SELECT k1, k2, orphan FROM t), d2 AS (SELECT k1, k2 FROM d1) \
+            SELECT k1 FROM d2", vec!["k2", "orphan"])]
+    // SELECT * in the final query marks every source column used.
+    #[case("WITH cte1 AS (SELECT col1, col2 FROM t) SELECT * FROM cte1", vec![])]
+    // UNNEST marks arr used; the final SELECT marks other used.
+    #[case("WITH cte1 AS (SELECT arr, other FROM t) SELECT other FROM cte1, UNNEST(arr) AS x", vec![])]
+    fn fires_identically_on_the_googlesql_backend(
+        #[case] sql: &str,
+        #[case] expected_unused: Vec<&str>,
+    ) {
+        let diagnostics = run_rule(&UnusedColumnInCte, sql);
+
+        let mut found: Vec<String> = diagnostics
+            .iter()
+            .map(|d| {
+                d.message()
+                    .strip_prefix("Unused column: ")
+                    .unwrap_or_else(|| d.message())
+                    .to_string()
+            })
+            .collect();
+        found.sort();
+
+        let mut expected: Vec<String> = expected_unused.iter().map(|s| (*s).to_string()).collect();
+        expected.sort();
+
+        assert_eq!(found, expected, "unused columns mismatch for: {sql}");
+    }
 }

--- a/src/rules/unused_column_in_cte/utils.rs
+++ b/src/rules/unused_column_in_cte/utils.rs
@@ -8,13 +8,26 @@ use super::models::ColumnInfo;
 
 /// Extract CTE name from a CTE node.
 ///
-/// A well-formed CTE always has an `alias_name` field. On a malformed tree
-/// where it is missing we return an empty name rather than panicking; an empty
-/// CTE name simply fails to match downstream lookups.
+/// On googlesql an `ASTAliasedQuery`'s first child is the CTE name identifier.
+/// On a malformed tree where it is missing we return an empty name rather than
+/// panicking; an empty CTE name simply fails to match downstream lookups.
 pub fn get_cte_name<'a>(cte_node: &NodeRef<'_>, sql: &'a str) -> &'a str {
-    cte_node
-        .child_by_field_name("alias_name")
-        .map_or("", |alias_node| get_node_text(&alias_node, sql))
+    if cte_node.kind() == "ASTAliasedQuery"
+        && let Some(name_node) = cte_node.child(0)
+    {
+        return get_node_text(&name_node, sql);
+    }
+    ""
+}
+
+/// True when a select-list child represents `*`.
+///
+/// googlesql wraps the `ASTStar` in an `ASTSelectColumn`, so the star is one
+/// level deeper. This hides that nesting for the select-list scanners.
+pub fn is_star_select_item(child: &NodeRef<'_>) -> bool {
+    child.kind() == "ASTStar"
+        || (child.kind() == "ASTSelectColumn"
+            && child.children().into_iter().any(|c| c.kind() == "ASTStar"))
 }
 
 /// Extract column name from a potentially qualified column reference
@@ -39,16 +52,19 @@ pub fn extract_table(
 
     if let Some(from_node) = from {
         for n in from_node.pre_order() {
-            if n.kind() == "from_item"
+            // A table reference: `ASTTablePathExpression` on googlesql. Its first
+            // named child names the table (an `ASTPathExpression`); UNNEST/subquery
+            // items whose first child is not are skipped.
+            if n.kind() == "ASTTablePathExpression"
                 && let Some(first_child) = n.named_child(0)
-                && first_child.kind() == "identifier"
+                && first_child.kind() == "ASTPathExpression"
             {
                 let table_name = get_node_text(&first_child, sql).to_string();
                 tables.push(table_name.clone());
 
-                // Check if there's an alias
+                // Check if there's an alias (`ASTAlias`).
                 for child in n.children() {
-                    if child.kind() == "as_alias" {
+                    if child.kind() == "ASTAlias" {
                         if let Some(alias_node) = child.named_children().into_iter().last() {
                             let alias_name = get_node_text(&alias_node, sql).to_string();
                             alias_map.insert(alias_name, table_name.clone());
@@ -182,8 +198,9 @@ pub fn extract_and_mark_fields(
     resolver: &TableResolver,
     context: &mut AnalysisContext,
 ) {
-    // Process current node if it's a field, identifier, or input_column
-    if node.kind() == "field" || node.kind() == "identifier" || node.kind() == "input_column" {
+    // Process current node if it's a column reference: an `ASTPathExpression`
+    // (which carries the whole possibly-qualified name as its text) on googlesql.
+    if node.kind() == "ASTPathExpression" {
         // Skip function names
         if is_function_name(node) {
             return;

--- a/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/cte_visitor.rs
@@ -9,29 +9,31 @@ pub struct CteVisitor;
 
 impl NodeVisitor for CteVisitor {
     fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
-        if node.kind() != "cte" {
+        // A CTE definition: `ASTAliasedQuery` on googlesql.
+        if node.kind() != "ASTAliasedQuery" {
             return;
         }
 
         let sql = context.sql();
         let cte_name = utils::get_cte_name(&node, sql).to_string();
 
-        // Find the SELECT or query_expr that defines this CTE
+        // Find the SELECT (or the query wrapper around it) that defines this CTE.
+        // googlesql wraps the SELECT in an `ASTQuery`.
         let query_node = node
             .named_children()
             .into_iter()
-            .find(|child| child.kind() == "select" || child.kind() == "query_expr");
+            .find(|child| matches!(child.kind(), "ASTSelect" | "ASTQuery"));
 
         if let Some(query) = query_node {
-            let select_node = if query.kind() == "query_expr" {
-                find_child_of_kind(&query, "select")
+            let select_node = if query.kind() == "ASTQuery" {
+                find_child_of_kind(&query, "ASTSelect")
             } else {
                 Some(query)
             };
 
             if let Some(sel) = select_node {
                 // Find the select_list within this SELECT
-                if let Some(select_list) = find_child_of_kind(&sel, "select_list") {
+                if let Some(select_list) = find_child_of_kind(&sel, "ASTSelectList") {
                     let columns = extract_columns(&select_list, sql, &context.cte_columns);
                     context.add_cte(cte_name, columns);
                 }
@@ -51,7 +53,7 @@ fn extract_columns(
 ) -> Vec<ColumnInfo> {
     let mut columns = Vec::new();
 
-    if node.kind() != "select_list" {
+    if node.kind() != "ASTSelectList" {
         return columns;
     }
 
@@ -60,12 +62,14 @@ fn extract_columns(
     let resolver = utils::TableResolver::new(&tables, &alias_map, cte_columns);
 
     for child in node.children() {
-        if child.kind() == "select_expression" {
-            let column_info = extract_column_info_from_select_expression(&child, sql, &resolver);
-            columns.push(column_info);
-        } else if child.kind() == "select_all" {
+        // The star check comes first: on googlesql a `*` is itself an
+        // `ASTSelectColumn`, which would otherwise match the column branch.
+        if utils::is_star_select_item(&child) {
             let position = child.start_position();
             columns.extend(expand_asterisk(position, &tables, cte_columns));
+        } else if child.kind() == "ASTSelectColumn" {
+            let column_info = extract_column_info_from_select_expression(&child, sql, &resolver);
+            columns.push(column_info);
         }
     }
 
@@ -78,11 +82,11 @@ fn extract_column_info_from_select_expression(
     sql: &str,
     resolver: &utils::TableResolver,
 ) -> ColumnInfo {
-    // Check if there's an as_alias child
+    // Check if there's an alias child (`ASTAlias`)
     let as_alias_node = select_expr
         .children()
         .into_iter()
-        .find(|n| n.kind() == "as_alias");
+        .find(|n| n.kind() == "ASTAlias");
 
     // Extract column information (with or without alias)
     let (column, original_column, source_column) = as_alias_node.map_or_else(

--- a/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/pivot_visitor.rs
@@ -8,8 +8,8 @@ pub struct PivotVisitor;
 
 impl NodeVisitor for PivotVisitor {
     fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
-        // Look for PIVOT operator
-        if node.kind() != "pivot_operator" {
+        // Look for PIVOT operator (`ASTPivotClause`)
+        if node.kind() != "ASTPivotClause" {
             return;
         }
 
@@ -34,12 +34,12 @@ fn find_tables_for_pivot(
     let mut current = pivot_node.parent();
     while let Some(parent) = current {
         // Check if this is a from_clause
-        if parent.kind() == "from_clause" {
+        if parent.kind() == "ASTFromClause" {
             return utils::extract_table(Some(parent), sql);
         }
         // Check if this is inside a SELECT that has a FROM clause
-        if parent.kind() == "select"
-            && let Some(from) = crate::rules::helpers::find_child_of_kind(&parent, "from_clause")
+        if parent.kind() == "ASTSelect"
+            && let Some(from) = crate::rules::helpers::find_child_of_kind(&parent, "ASTFromClause")
         {
             return utils::extract_table(Some(from), sql);
         }

--- a/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/qualify_visitor.rs
@@ -11,7 +11,7 @@ impl NodeVisitor for QualifyVisitor {
     fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
         // Look for QUALIFY clause
         // BigQuery's QUALIFY is used after SELECT to filter window function results
-        if node.kind() != "qualify_clause" {
+        if node.kind() != "ASTQualify" {
             return;
         }
 
@@ -21,7 +21,7 @@ impl NodeVisitor for QualifyVisitor {
             return;
         };
 
-        let from_node = find_child_of_kind(&select_node, "from_clause");
+        let from_node = find_child_of_kind(&select_node, "ASTFromClause");
         let (tables, alias_map) = utils::extract_table(from_node, sql);
         let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 

--- a/src/rules/unused_column_in_cte/visitors/select_star_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_star_visitor.rs
@@ -8,15 +8,16 @@ pub struct SelectStarVisitor;
 
 impl NodeVisitor for SelectStarVisitor {
     fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
-        if node.kind() != "select_list" {
+        if node.kind() != "ASTSelectList" {
             return;
         }
 
-        // Check if this select_list contains SELECT *
+        // Check if this select_list contains SELECT * (an `ASTSelectColumn`
+        // wrapping an `ASTStar` on googlesql).
         let has_select_star = node
             .children()
             .into_iter()
-            .any(|child| child.kind() == "select_all");
+            .any(|child| utils::is_star_select_item(&child));
 
         if !has_select_star {
             return;
@@ -26,7 +27,7 @@ impl NodeVisitor for SelectStarVisitor {
         let mut current = node.parent();
         let mut in_cte = false;
         while let Some(parent) = current {
-            if parent.kind() == "cte" {
+            if parent.kind() == "ASTAliasedQuery" {
                 in_cte = true;
                 break;
             }

--- a/src/rules/unused_column_in_cte/visitors/select_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/select_visitor.rs
@@ -19,7 +19,7 @@ impl SelectVisitor {
         // Check if this SELECT is inside a CTE
         let mut current = node.parent();
         while let Some(parent) = current {
-            if parent.kind() == "cte" {
+            if parent.kind() == "ASTAliasedQuery" {
                 return false; // Inside a CTE
             }
             current = parent.parent();
@@ -30,12 +30,12 @@ impl SelectVisitor {
 
 impl NodeVisitor for SelectVisitor {
     fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
-        if node.kind() == "select" {
+        if node.kind() == "ASTSelect" {
             let sql = context.sql();
             let is_final_select = self.is_final_select(&node);
 
             // Find the select_list within the SELECT
-            if let Some(select_list) = find_child_of_kind(&node, "select_list") {
+            if let Some(select_list) = find_child_of_kind(&node, "ASTSelectList") {
                 if is_final_select {
                     // For final SELECT: extract and mark columns through dependency tracing
                     let final_columns = extract_final_select_columns(&select_list, sql, context);
@@ -76,7 +76,7 @@ fn extract_and_mark_expression_columns(
 
     // Process each select_expression
     for child in select_list.children() {
-        if child.kind() == "select_expression" {
+        if child.kind() == "ASTSelectColumn" {
             // Extract all field references from the expression (including nested ones in function calls)
             extract_field_references_from_expression(&child, sql, &resolver, context);
         }
@@ -87,12 +87,8 @@ fn extract_and_mark_expression_columns(
 fn find_parent_cte_name(select_node: &NodeRef<'_>, sql: &str) -> String {
     let mut current = select_node.parent();
     while let Some(parent) = current {
-        if parent.kind() == "cte" {
-            return parent
-                .child_by_field_name("alias_name")
-                .map(|n| get_node_text(&n, sql))
-                .unwrap_or("")
-                .to_string();
+        if parent.kind() == "ASTAliasedQuery" {
+            return utils::get_cte_name(&parent, sql).to_string();
         }
         current = parent.parent();
     }
@@ -107,8 +103,9 @@ fn extract_field_references_from_expression(
     resolver: &utils::TableResolver,
     context: &mut AnalysisContext,
 ) {
-    // Process current node if it's a field or identifier
-    if node.kind() == "field" || node.kind() == "identifier" {
+    // Process current node if it's a column reference (`ASTPathExpression` on
+    // googlesql).
+    if node.kind() == "ASTPathExpression" {
         if is_function_name(node) {
             return;
         }
@@ -143,16 +140,37 @@ fn extract_final_select_columns(
     let resolver = utils::TableResolver::new(&tables, &alias_map, &context.cte_columns);
 
     for child in select_list.children() {
-        if child.kind() == "select_expression" {
+        // The star check comes first: on googlesql a `*` is itself an
+        // `ASTSelectColumn`, which would otherwise match the column branch.
+        if utils::is_star_select_item(&child) {
+            // SELECT * - expand to all columns from referenced tables
+            for table in &tables {
+                if let Some(cols) = context.get_cte_columns(table) {
+                    for col in cols {
+                        columns.push(ColumnInfo::new(
+                            Some(table.clone()),
+                            col.column_name.clone(),
+                            None,
+                            child.start_position().row,
+                            child.start_position().column,
+                        ));
+                    }
+                }
+            }
+        } else if child.kind() == "ASTSelectColumn" {
             // Strategy: First try to get the direct field reference,
             // then recursively find all field nodes (for function arguments, etc.)
 
-            // Check if this has a direct field child (simple column reference)
-            let has_direct_field = child.children().into_iter().any(|c| c.kind() == "field");
+            // Check if this has a direct column-reference child. On googlesql the
+            // column reference is an `ASTPathExpression`.
+            let has_direct_field = child
+                .children()
+                .into_iter()
+                .any(|c| c.kind() == "ASTPathExpression");
 
             if !has_direct_field {
                 // Fallback: treat the whole expression text as a column reference
-                // This handles cases where tree-sitter doesn't create a 'field' node
+                // (e.g. an expression that is not a plain column).
                 let column_text = get_node_text(&child, sql);
                 let col_name = utils::extract_column_name(column_text);
 
@@ -171,21 +189,6 @@ fn extract_final_select_columns(
 
             // Recurse to find any nested fields (after both branches)
             extract_all_fields_into_vec(&child, sql, &resolver, &mut columns);
-        } else if child.kind() == "select_all" {
-            // SELECT * - expand to all columns from referenced tables
-            for table in &tables {
-                if let Some(cols) = context.get_cte_columns(table) {
-                    for col in cols {
-                        columns.push(ColumnInfo::new(
-                            Some(table.clone()),
-                            col.column_name.clone(),
-                            None,
-                            child.start_position().row,
-                            child.start_position().column,
-                        ));
-                    }
-                }
-            }
         }
     }
 
@@ -199,10 +202,10 @@ fn extract_all_fields_into_vec(
     resolver: &utils::TableResolver,
     columns: &mut Vec<ColumnInfo>,
 ) {
-    // Process current node if it's a field or identifier
-    // Note: tree-sitter may use 'field' for qualified references (table.column)
-    // and 'identifier' for simple column references
-    if node.kind() == "field" || node.kind() == "identifier" {
+    // Process current node if it's a column reference. googlesql uses
+    // `ASTPathExpression` for both simple and qualified references (its text
+    // carries the whole possibly-qualified name).
+    if node.kind() == "ASTPathExpression" {
         if is_function_name(node) {
             return;
         }

--- a/src/rules/unused_column_in_cte/visitors/where_visitor.rs
+++ b/src/rules/unused_column_in_cte/visitors/where_visitor.rs
@@ -13,13 +13,10 @@ pub struct WhereVisitor;
 
 impl NodeVisitor for WhereVisitor {
     fn visit(&self, node: NodeRef<'_>, context: &mut AnalysisContext) {
-        // Process JOIN conditions, WHERE clauses, and GROUP BY
-        if matches!(
-            node.kind(),
-            "join_condition" | "where_clause" | "group_by_clause"
-        ) {
+        // Process JOIN conditions, WHERE clauses, and GROUP BY (googlesql kinds).
+        if matches!(node.kind(), "ASTOnClause" | "ASTWhereClause" | "ASTGroupBy") {
             process_condition_node(&node, context);
-        } else if node.kind() == "from_clause" {
+        } else if node.kind() == "ASTFromClause" {
             // Process UNNEST functions in FROM clause
             process_unnest_in_from(&node, context);
         }
@@ -51,7 +48,7 @@ fn extract_tables_from_parent(
     sql: &str,
 ) -> (Vec<String>, HashMap<String, String>) {
     if let Some(select_node) = find_parent_select(node) {
-        let from_node = find_child_of_kind(&select_node, "from_clause");
+        let from_node = find_child_of_kind(&select_node, "ASTFromClause");
         return utils::extract_table(from_node, sql);
     }
     (Vec::new(), HashMap::new())
@@ -68,10 +65,10 @@ fn process_unnest_in_from(from_node: &NodeRef<'_>, context: &mut AnalysisContext
 
     // Find all UNNEST clauses in FROM clause (BigQuery-specific syntax)
     for child in from_node.pre_order() {
-        if child.kind() == "unnest_operator" || child.kind() == "unnest_clause" {
+        if child.kind() == "ASTUnnestExpression" {
             // Extract identifiers from UNNEST - these are the column references
             for unnest_child in child.pre_order() {
-                if unnest_child.kind() == "identifier" || unnest_child.kind() == "field" {
+                if unnest_child.kind() == "ASTPathExpression" {
                     let column_text = get_node_text(&unnest_child, sql);
                     let table = resolver.resolve_qualified_or(column_text);
 
@@ -107,7 +104,7 @@ fn extract_columns_from_condition(
 ) {
     // Traverse the condition tree to find all column references
     for child in node.pre_order() {
-        if child.kind() == "field" || child.kind() == "identifier" {
+        if child.kind() == "ASTPathExpression" {
             // Skip function names
             if is_function_name(&child) {
                 continue;

--- a/src/rules/use_current_date.rs
+++ b/src/rules/use_current_date.rs
@@ -24,7 +24,9 @@ impl Rule for UseCurrentDate {
 fn current_date_used(node: NodeRef<'_>, src: &str) -> Option<Diagnostic> {
     let text = get_node_text(&node, src);
 
-    if node.kind() == "identifier" && text.eq_ignore_ascii_case("current_date") {
+    // The identifier node is `ASTIdentifier` on the googlesql (ZetaSQL) backend.
+    let is_identifier = node.kind() == "ASTIdentifier";
+    if is_identifier && text.eq_ignore_ascii_case("current_date") {
         let (row, col) = one_based_start(&node);
         return Some(Diagnostic::new(
             RULE_ID,


### PR DESCRIPTION
## What

Completes the parser migration by removing the tree-sitter backend entirely. googlesql (ZetaSQL, `native-ffi` backend) is now the only parser.

- **rules**: collapse every dual-match (tree-sitter lowercase kinds + ZetaSQL `AST*` kinds) down to the ZetaSQL arm; drop the tree-sitter BETWEEN (`between_from`/`between_to`) path and the `child_by_field_name("function")` fallback
- **ast**: remove `from_tree_sitter`/`build` and the now-dead field-based navigation (`field_name` / `child_by_field_name` are always empty on ZetaSQL)
- **main**: remove the hidden `--parser` flag, the `Backend` enum and the tree-sitter analysis path; googlesql is unconditional (rayon builds one `Module` per worker)
- **helpers**: unify the test path on googlesql (`parse_sql`/`run_rule`); drop the redundant `*_googlesql` helpers and the unused `find_child_of_any_kind`
- **deps**: remove `tree-sitter`, `tree-sitter-sql-bigquery`, `baz-tree-sitter-traversal`

## Breaking / behaviour changes

googlesql has no error recovery, so:
- a parse failure yields **zero diagnostics** for that input, with the error on **stderr**
- a syntax error in one statement fails that **whole statement**
- qualified GROUP BY columns are reported by their **leaf name** (e.g. `col3`) rather than the fully qualified `t1.col3`
- `sql/valid_order_by_with_limit.sql` gains statement separators, which ZetaSQL requires

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings -W clippy::nursery` clean
- 188 tests pass
- `bqvalid sql/` produces byte-identical diagnostics (41 lines) to the pre-flip googlesql path, with clean stderr

Rebased onto latest `main` (picks up the dependabot clap/serde/serde_json bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)