### PR TITLE
feat(dist): hybrid parser backend, native-ffi opt-in with bundled sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 # dhat heap profiling
 dhat-*.json
 dhat/
+
+# goreleaser output and the native-ffi sidecar its build hook stages at the repo
+# root before archiving (see .goreleaser.yaml)
+/dist/
+/libguest_ffi.so
+/libguest_ffi.dylib
+
+# Local Claude Code guidance, kept out of version control
+/CLAUDE.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,52 +2,145 @@ version: 2
 
 project_name: bqvalid
 
+# Hybrid backend per target. googlesql's `native-ffi` engine is faster but links a
+# prebuilt `libguest_ffi` C-ABI shared library that is only prebuilt for
+# x86_64-linux and aarch64-darwin, and needs that sidecar shipped next to the
+# binary. Those two targets are therefore built with `--features native-ffi` (on a
+# runner of their own arch, so googlesql's build.rs downloads the matching prebuilt)
+# and bundle the sidecar into the archive. The other two targets are cross-built and
+# use the default, self-contained wasmtime backend (no sidecar).
 builds:
-  - id: build-linux-windows
+  - id: linux-nativeffi
     skip: '{{ eq .Runtime.Goos "darwin" }}'
     builder: rust
     binary: bqvalid
     targets:
       - x86_64-unknown-linux-gnu
+    tool: cargo
+    command: zigbuild
+    flags:
+      - --release
+      - --features
+      - native-ffi
+    env:
+      - BUILD_VERSION={{ .Version }}
+    hooks:
+      # Copy the cdylib googlesql's build.rs downloaded into OUT_DIR to a stable
+      # path for the archive. A fresh CI checkout has exactly one googlesql-* dir.
+      post:
+        - sh -c 'cp target/x86_64-unknown-linux-gnu/release/build/googlesql-*/out/libguest_ffi.so ./libguest_ffi.so'
+
+  - id: windows-wasmtime
+    skip: '{{ eq .Runtime.Goos "darwin" }}'
+    builder: rust
+    binary: bqvalid
+    targets:
       - x86_64-pc-windows-gnu
     tool: cargo
     command: zigbuild
     flags:
       - --release
-      - --all-features
     env:
       - BUILD_VERSION={{ .Version }}
 
-  - id: build-macos
+  - id: macos-nativeffi
     skip: '{{ ne .Runtime.Goos "darwin" }}'
     builder: rust
     binary: bqvalid
     targets:
-      - x86_64-apple-darwin
       - aarch64-apple-darwin
     tool: cross
     command: build
     flags:
       - --release
-      - --all-features
+      - --features
+      - native-ffi
+    env:
+      - BUILD_VERSION={{ .Version }}
+    hooks:
+      post:
+        - sh -c 'cp target/aarch64-apple-darwin/release/build/googlesql-*/out/libguest_ffi.dylib ./libguest_ffi.dylib'
+
+  - id: macos-wasmtime
+    skip: '{{ ne .Runtime.Goos "darwin" }}'
+    builder: rust
+    binary: bqvalid
+    targets:
+      - x86_64-apple-darwin
+    tool: cross
+    command: build
+    flags:
+      - --release
     env:
       - BUILD_VERSION={{ .Version }}
 
+# Naming is unchanged from the previous single archive: bqvalid-<arch>-<os>. The
+# native-ffi archives additionally carry libguest_ffi.{so,dylib} next to the binary;
+# bqvalid's build.rs bakes an @executable_path/$ORIGIN rpath so it loads from there.
 archives:
-  - formats: [ 'tar.gz' ]
-    format_overrides:
-      - goos: windows
-        formats: [ 'zip' ]
+  - id: linux-nativeffi
+    ids:
+      - linux-nativeffi
+    formats: [ 'tar.gz' ]
     name_template: >-
       {{ .ProjectName }}-
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}-
       {{- .Os }}
+    files:
+      - LICENSE
+      - README.md
+      - src: libguest_ffi.so
+        strip_parent: true
+
+  - id: macos-nativeffi
     ids:
-      - build-linux-windows
-      - build-macos
-    allow_different_binary_count: true
+      - macos-nativeffi
+    formats: [ 'tar.gz' ]
+    name_template: >-
+      {{ .ProjectName }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}-
+      {{- .Os }}
+    files:
+      - LICENSE
+      - README.md
+      - src: libguest_ffi.dylib
+        strip_parent: true
+
+  # One archive per build id. windows-wasmtime and macos-wasmtime are produced on
+  # different runners (see each build's `skip:`), so a single archive referencing
+  # both would have a per-platform binary-count mismatch on each runner; keeping
+  # them separate (like the native-ffi archives above) sidesteps that entirely.
+  - id: windows-wasmtime
+    ids:
+      - windows-wasmtime
+    formats: [ 'zip' ]
+    name_template: >-
+      {{ .ProjectName }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}-
+      {{- .Os }}
+    files:
+      - LICENSE
+      - README.md
+
+  - id: macos-wasmtime
+    ids:
+      - macos-wasmtime
+    formats: [ 'tar.gz' ]
+    name_template: >-
+      {{ .ProjectName }}-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}-
+      {{- .Os }}
+    files:
+      - LICENSE
+      - README.md
 
 checksum:
   disable: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,9 +1020,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "googlesql"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945ebcea0b36ba2cbe83fbd1e1b5004fbeb14a39f03912c5a832a717e9ddbc14"
+checksum = "af5bab3e6274f69486266d694765b182d6fed982ee6cb244b7800fc29957b70c"
 dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,17 @@ log = "0.4.32"
 env_logger = "0.11.10"
 clap-verbosity-flag = "3.0.4"
 rayon = "1.12.0"
-googlesql = { version = "0.3.0", features = ["native-ffi"] }
+googlesql = { version = "0.3.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.9"
+
+[features]
+# Default: the self-contained wasmtime backend — no sidecar, builds on every
+# target. Enable `native-ffi` to link googlesql's prebuilt C-ABI shared library
+# instead (faster, but ships a `libguest_ffi` sidecar and is only prebuilt for
+# some targets). Release archives select per target; see `.goreleaser.yaml`.
+native-ffi = ["googlesql/native-ffi"]
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/benches/memory_profile.rs
+++ b/benches/memory_profile.rs
@@ -42,7 +42,7 @@ fn main() {
 
     println!("Starting memory profiling...");
 
-    let mut module = Module::new_native_ffi().expect("googlesql module builds");
+    let mut module = bqvalid::build_module().expect("googlesql module builds");
     run_check(&mut module, "small", "./benches/fixtures/bench_small.sql");
     run_check(&mut module, "medium", "./benches/fixtures/bench_medium.sql");
     run_check(&mut module, "large", "./benches/fixtures/bench_large.sql");

--- a/benches/unused_column_in_cte.rs
+++ b/benches/unused_column_in_cte.rs
@@ -27,7 +27,7 @@ fn bench_unused_column_check(c: &mut Criterion) {
     ];
 
     let mut group = c.benchmark_group("unused_column_in_cte");
-    let mut module = Module::new_native_ffi().expect("googlesql module builds");
+    let mut module = bqvalid::build_module().expect("googlesql module builds");
 
     for (name, path) in test_cases {
         let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
@@ -56,7 +56,7 @@ fn bench_parse_and_check(c: &mut Criterion) {
     ];
 
     let mut group = c.benchmark_group("parse_and_check");
-    let mut module = Module::new_native_ffi().expect("googlesql module builds");
+    let mut module = bqvalid::build_module().expect("googlesql module builds");
 
     for (name, path) in test_cases {
         let sql = fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,38 @@
+//! Wires up the run-time search paths for the `native-ffi` backend's sidecar.
+//!
+//! The default (wasmtime) backend is self-contained and needs nothing here. Under
+//! the `native-ffi` feature the binary links googlesql's prebuilt `libguest_ffi`
+//! C-ABI shared library, whose reference is relocatable (`@rpath` install name /
+//! bare `SONAME`). Resolving it at run time is the consumer's job: a dependency's
+//! build script cannot bake an rpath into this binary's link. googlesql publishes
+//! the directory it resolved the cdylib to as `DEP_GUEST_FFI_LIBDIR` (via its
+//! `links = "guest_ffi"`); we turn that into two rpaths — one for development
+//! (`cargo run`/`cargo test`) and one for a shipped binary that carries a copy of
+//! the library next to itself. See googlesql's `docs/NATIVE.md`.
+
+fn main() {
+    // Only the native-ffi backend links the sidecar; the wasmtime default embeds
+    // the parser and needs no search paths. Skipping the rpath args otherwise
+    // also keeps them off targets that never use native-ffi (e.g. Windows, where
+    // `-Wl,-rpath` is meaningless).
+    if std::env::var_os("CARGO_FEATURE_NATIVE_FFI").is_none() {
+        return;
+    }
+    println!("cargo::rerun-if-env-changed=DEP_GUEST_FFI_LIBDIR");
+
+    // Development: load the cdylib from wherever googlesql resolved it (OUT_DIR on
+    // the download path, or a local GUEST_FFI_LIB). Only a direct dependent of
+    // googlesql receives this — bqvalid depends on it directly, so it is set.
+    if let Ok(dir) = std::env::var("DEP_GUEST_FFI_LIBDIR") {
+        println!("cargo::rustc-link-arg=-Wl,-rpath,{dir}");
+    }
+
+    // Shipped binary: load a copy of libguest_ffi.{dylib,so} placed next to the
+    // executable (the release archive bundles it — see `.goreleaser.yaml`).
+    let origin = if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        "@executable_path"
+    } else {
+        "$ORIGIN"
+    };
+    println!("cargo::rustc-link-arg=-Wl,-rpath,{origin}");
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -480,12 +480,11 @@ mod googlesql_tests {
     use super::*;
     use googlesql::Module;
 
-    /// A fresh googlesql module on the `native-ffi` backend. Building it links
-    /// the prebuilt ZetaSQL shared library rather than JIT-compiling the wasm, so
-    /// each test pays a small one-time cost; reuse the returned module across as
-    /// many parses as the test needs.
+    /// A fresh googlesql module on the compile-time-selected backend. Building it
+    /// links/loads the ZetaSQL parser, so each test pays a small one-time cost;
+    /// reuse the returned module across as many parses as the test needs.
     fn module() -> Module {
-        Module::new_native_ffi().expect("load googlesql native-ffi module")
+        crate::build_module().expect("load googlesql module")
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,23 @@ pub mod config;
 pub mod diagnostic;
 pub mod output;
 pub mod rules;
+
+/// Build a googlesql (ZetaSQL) parser [`Module`](googlesql::Module) using the
+/// backend chosen at compile time.
+///
+/// By default the self-contained wasmtime engine ([`Module::new`](googlesql::Module::new))
+/// is used: it embeds the precompiled ZetaSQL wasm and needs no sidecar, so it
+/// builds and runs on every target. With the `native-ffi` feature the parser is
+/// instead linked as a prebuilt C-ABI shared library and run as native code
+/// ([`Module::new_native_ffi`](googlesql::Module::new_native_ffi)) — faster, but
+/// it ships a `libguest_ffi` sidecar and is only prebuilt for some targets.
+///
+/// Both backends materialize the identical neutral AST, so the choice is
+/// invisible past construction.
+pub fn build_module() -> Result<googlesql::Module, googlesql::Error> {
+    #[cfg(feature = "native-ffi")]
+    let module = googlesql::Module::new_native_ffi();
+    #[cfg(not(feature = "native-ffi"))]
+    let module = googlesql::Module::new();
+    module
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,11 +148,10 @@ fn is_sql(entry: &DirEntry) -> bool {
 /// Build a googlesql (ZetaSQL) parser module. Returns `None` if the module fails
 /// to initialize (logged to stderr).
 ///
-/// Uses the `native-ffi` backend ([`Module::new_native_ffi`]): the ZetaSQL parser
-/// linked as a prebuilt C-ABI shared library and run as native code, rather than
-/// the default wasmtime engine that JIT-compiles the wasm on first use.
+/// The backend (wasmtime by default, native-ffi under the `native-ffi` feature)
+/// is chosen at compile time by [`bqvalid::build_module`].
 fn new_module() -> Option<Module> {
-    match Module::new_native_ffi() {
+    match bqvalid::build_module() {
         Ok(module) => Some(module),
         Err(e) => {
             eprintln!("Error initializing googlesql parser: {}", e);

--- a/src/rules/helpers.rs
+++ b/src/rules/helpers.rs
@@ -103,9 +103,7 @@ pub fn is_function_name(node: &NodeRef<'_>) -> bool {
     reason = "test code"
 )]
 pub fn parse_sql(sql: &str) -> crate::ast::Ast {
-    use googlesql::Module;
-
-    let mut module = Module::new_native_ffi().expect("googlesql module builds");
+    let mut module = crate::build_module().expect("googlesql module builds");
     crate::ast::Ast::from_googlesql(&mut module, sql).expect("googlesql parses the sql")
 }
 


### PR DESCRIPTION
## What

Makes the googlesql parser backend selectable at compile time and turns the `native-ffi` build into a self-sufficient, distributable artifact. Follow-up to #84 (which made googlesql the sole parser, hardcoded to native-ffi).

## Why

native-ffi is faster but links a prebuilt `libguest_ffi` C-ABI shared library that (a) must be shipped next to the binary and (b) is only prebuilt for `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`. Hardcoding it broke distribution for Windows and Intel-Mac. This PR keeps native-ffi where it's supported and falls back to the self-contained wasmtime backend everywhere else.

## Changes

- **`src/lib.rs`**: new `build_module()` — the single place that selects the backend. Default `Module::new()` (wasmtime, embeds the ZetaSQL wasm, no sidecar, builds on every target); `Module::new_native_ffi()` under the new `native-ffi` feature.
- **`Cargo.toml`**: drop the unconditional `native-ffi` on the googlesql dep, expose it as a bqvalid `[features] native-ffi`; bump googlesql `0.3.0 → 0.3.1` (relocatable `@rpath` cdylib + `DEP_GUEST_FFI_LIBDIR`).
- **`build.rs`** (new, active only under `native-ffi`): turn `DEP_GUEST_FFI_LIBDIR` into a dev rpath and add an `@executable_path`/`$ORIGIN` rpath so a shipped binary loads the bundled sidecar.
- **call sites** (`main.rs`, `ast.rs`, `rules/helpers.rs`, `benches/*`): build via `build_module()` instead of calling `Module::new_native_ffi()` directly.
- **`.goreleaser.yaml`**: hybrid release — `x86_64-linux` + `aarch64-darwin` built with `--features native-ffi` and bundle `libguest_ffi.{so,dylib}`; `x86_64-windows` + `x86_64-darwin` use wasmtime. One archive per build id (avoids a cross-runner binary-count mismatch). `.gitignore` the staged sidecar and `dist/`.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings -W clippy::nursery` clean under **both** default and `--features native-ffi`
- 188 tests pass; `bqvalid sql/` produces **byte-identical** diagnostics on both backends (clean stderr)
- `goreleaser check` passes; a local snapshot archive bundles `libguest_ffi.dylib` next to the binary
- **Standalone run proven**: extracted the release archive, stripped the dev rpath (simulating a user machine), and ran from a clean env (`env -i`, no `DYLD_*`) — resolves the bundled sidecar via `@executable_path` and lints correctly; without the sidecar it fails loudly (dyld image not found)

## Notes / out of scope

- CI's coverage job (`--all-features`) is the only job that compiles native-ffi; the stable/beta/nightly matrix uses the default wasmtime backend. Adding a native-ffi build/clippy job could be a follow-up.
- `README.md`'s macOS download line references `bqvalid-x86_64-apple-darwin`, but goreleaser emits `bqvalid-x86_64-darwin` (pre-existing mismatch, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)