### PR TITLE
docs+ci: fix install instructions and cover the native-ffi backend

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,27 @@ jobs:
       - name: Run cargo test
         run: cargo test --release
 
+  # The stable/beta/nightly matrix above builds the default (wasmtime) backend.
+  # This job exercises the native-ffi compile path that release archives ship for
+  # x86_64-linux: build.rs's rpath wiring, the `#[cfg(feature = "native-ffi")]`
+  # arm, and googlesql's prebuilt-cdylib download (a prebuilt exists for this
+  # target, so build.rs fetches it).
+  native-ffi:
+    name: Check native-ffi backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install stable
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup default stable
+
+      - name: Run cargo clippy (native-ffi)
+        run: cargo clippy --all-targets --features native-ffi -- -D warnings -W clippy::nursery
+
+      - name: Run cargo test (native-ffi)
+        run: cargo test --release --features native-ffi
+
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@
 
 ## Installation
 
-You can get binary of `bqvalid` from the release page like
+Download the archive for your platform from the [release page](https://github.com/hirosassa/bqvalid/releases) and extract the `bqvalid` binary. The assets are named `bqvalid-<arch>-<os>`:
+
+- `bqvalid-x86_64-linux.tar.gz`
+- `bqvalid-arm64-darwin.tar.gz` (Apple Silicon)
+- `bqvalid-x86_64-darwin.tar.gz` (Intel Mac)
+- `bqvalid-x86_64-windows.zip`
+
+For example, on Apple Silicon:
 
 ```shell
-curl -LsJO https://github.com/hirosassa/bqvalid/releases/download/v0.0.9/bqvalid-x86_64-apple-darwin
+curl -LO https://github.com/hirosassa/bqvalid/releases/latest/download/bqvalid-arm64-darwin.tar.gz
+tar xzf bqvalid-arm64-darwin.tar.gz
+./bqvalid --help
 ```
+
+The Linux (`x86_64`) and Apple Silicon archives bundle a `libguest_ffi.{so,dylib}` shared library next to the binary; keep the two together (the binary loads it from its own directory). The Intel Mac and Windows builds are self-contained.
 
 ## Usage
 


### PR DESCRIPTION
Follow-ups to #85 (hybrid parser backend).

## README — correct the install instructions

The Installation snippet downloaded a bare `bqvalid-x86_64-apple-darwin`, which goreleaser has never produced (releases ship per-platform archives, e.g. `bqvalid-x86_64-darwin.tar.gz`). Replaced it with:
- the real asset names for all four platforms (`bqvalid-<arch>-<os>.tar.gz` / windows `.zip`)
- a download + `tar xzf` example (Apple Silicon)
- a note that the `x86_64-linux` and `arm64-darwin` archives bundle a `libguest_ffi.{so,dylib}` sidecar that must stay next to the binary (Intel-Mac / Windows builds are self-contained)

## CI — exercise the native-ffi backend

The stable/beta/nightly matrix builds the default wasmtime backend; native-ffi was only compiled in the coverage job. Added a `native-ffi` job (ubuntu/stable) that runs:
- `cargo clippy --all-targets --features native-ffi -- -D warnings -W clippy::nursery`
- `cargo test --release --features native-ffi`

This covers the native-ffi compile path the release archives actually ship for `x86_64-linux`: `build.rs`'s rpath wiring, the `#[cfg(feature = "native-ffi")]` arm, and googlesql's prebuilt-cdylib download (a prebuilt exists for this target, so `build.rs` fetches it).

## Verification

- `actionlint .github/workflows/test.yaml` clean
- Locally reproduced the new job: `cargo clippy --all-targets --features native-ffi -- -D warnings -W clippy::nursery` and `cargo test --release --features native-ffi` both pass (188 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)